### PR TITLE
[ISSUE #10] Upgrade Java 11→25 and Spring Boot 2.6.7→4.0.6

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,26 +10,27 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java for publishing to GitHub Packages
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '25'
+          distribution: 'temurin'
       - name: Publish to GitHub Packages
         run:  mvn --batch-mode deploy -DskipTests -Prelease-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: '25'
+          distribution: 'temurin'
 
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ How to use see the following introduction.
 
 ### 1. Install dependencies
 
-- JDK 11
+- JDK 25
 - MySQL8
-- Maven 3.8.5
+- Maven 3.9.15
 
 ### 2. Database initialization
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -15,12 +15,6 @@
     <name>distribution</name>
 
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <profiles>
         <profile>
             <id>release-rain-server</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,16 +48,12 @@
     <name>rain</name>
     <description>rain uid generator service</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <spring.boot.version>2.6.7</spring.boot.version>
-        <commons-lang3.version>3.9</commons-lang3.version>
-        <junit.version>4.13.1</junit.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <spring.boot.version>4.0.6</spring.boot.version>
         <revision>1.0.1</revision>
         <maven.flatten.version>1.2.5</maven.flatten.version>
-        <junit.version>5.8.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -83,29 +79,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>
                 <version>1.2.76</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -135,6 +111,14 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>${maven.flatten.version}</version>
@@ -162,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>3.5.4</version>
             </plugin>
         </plugins>
     </build>

--- a/rain-uidgenerator-client/pom.xml
+++ b/rain-uidgenerator-client/pom.xml
@@ -15,12 +15,6 @@
 
     <name>rain-uidgenerator-client</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -31,13 +25,11 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.1.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5-fluent</artifactId>
-            <version>5.1.3</version>
         </dependency>
 
         <dependency>
@@ -45,43 +37,6 @@
             <artifactId>fastjson</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-core</artifactId>
-            <version>1.35</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.35</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.11</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/UidClientTest.java
+++ b/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/UidClientTest.java
@@ -2,7 +2,12 @@ package com.github.mxsm.rain.uid.client;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.github.mxsm.rain.uid.client.service.SegmentUidGeneratorClientImpl;
+import com.github.mxsm.rain.uid.core.common.SnowflakeUidParsedResult;
+import com.github.mxsm.rain.uid.core.segment.Segment;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -12,32 +17,96 @@ import org.junit.jupiter.api.Test;
  */
 class UidClientTest {
 
-    private UidClient client;
+    @Test
+    void getSegmentUidReturnsConsecutiveLocalIds() {
+        SegmentUidGeneratorClientImpl client = new LocalSegmentUidGeneratorClient(4, 20);
 
-    @BeforeEach
-    void setUp() {
-        client = UidClient.builder().setUidGeneratorServerUir("172.23.186.56:8080").setSegmentNum(16).isSegmentUidFromRemote(false).build();
+        long firstUid = client.getUIDFromLocalCache("test-biz-code");
+        long secondUid = client.getUIDFromLocalCache("test-biz-code");
+        long thirdUid = client.getUIDFromLocalCache("test-biz-code");
+
+        assertEquals(firstUid + 1, secondUid);
+        assertEquals(secondUid + 1, thirdUid);
+        assertTrue(firstUid > 0);
     }
 
     @Test
-    void getSegmentUid() {
-        long segmentUid = client.getSegmentUid("uQG6n50NSIR6Fcuh19093632");
-        assertTrue(segmentUid > 0);
-    }
+    void getSegmentUidStartsFromFirstLocalSegment() {
+        SegmentUidGeneratorClientImpl client = new LocalSegmentUidGeneratorClient(2, 50);
 
-    @Test
-    void testGetSegmentUid() {
+        assertEquals(1L, client.getUIDFromLocalCache("test-biz-code"));
+        assertEquals(2L, client.getUIDFromLocalCache("test-biz-code"));
     }
 
     @Test
     void getSnowflakeUid() {
+        UidClient client = localClient();
+        try {
+            long uid = client.getSnowflakeUid();
+
+            assertTrue(uid > 0);
+        } finally {
+            client.shutdown();
+        }
     }
 
     @Test
     void parseSnowflakeUid() {
+        UidClient client = localClient();
+        try {
+            long uid = client.getSnowflakeUid();
+            SnowflakeUidParsedResult result = client.parseSnowflakeUid(uid);
+
+            assertEquals(uid, result.getUid());
+            assertNotNull(result.getTimestamp());
+            assertTrue(result.getMachineId() >= 0);
+            assertTrue(result.getSequence() >= 0);
+        } finally {
+            client.shutdown();
+        }
     }
 
     @Test
     void builder() {
+        UidClient client = localClient();
+        try {
+            assertNotNull(client);
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    private UidClient localClient() {
+        return UidClient.builder()
+            .isSegmentUidFromRemote(false)
+            .isSnowflakeUidFromRemote(false)
+            .build();
+    }
+
+    private static class LocalSegmentUidGeneratorClient extends SegmentUidGeneratorClientImpl {
+
+        private final AtomicLong nextSegmentStart = new AtomicLong(1);
+
+        LocalSegmentUidGeneratorClient(int segmentNum, int threshold) {
+            super(config(segmentNum, threshold));
+        }
+
+        @Override
+        public List<Segment> getSegments(String bizCode, int segmentNum) {
+            List<Segment> segments = new ArrayList<>(segmentNum);
+            for (int i = 0; i < segmentNum; i++) {
+                segments.add(new Segment(nextSegmentStart.getAndAdd(100), 100));
+            }
+            return segments;
+        }
+
+        private static Config config(int segmentNum, int threshold) {
+            Config config = new Config();
+            config.setSegmentNum(segmentNum);
+            config.setThreshold(threshold);
+            config.setSegmentUidFromRemote(false);
+            config.setSnowflakeUidFromRemote(false);
+            return config;
+        }
     }
 }

--- a/rain-uidgenerator-core/pom.xml
+++ b/rain-uidgenerator-core/pom.xml
@@ -15,19 +15,11 @@
 
     <name>rain-uidgenerator-core</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/rain-uidgenerator-jmh/pom.xml
+++ b/rain-uidgenerator-jmh/pom.xml
@@ -18,10 +18,7 @@
 
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <jmh.version>1.35</jmh.version>
+        <jmh.version>1.37</jmh.version>
     </properties>
 
     <dependencies>
@@ -52,8 +49,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -61,6 +72,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <finalName>benchmarks</finalName>
                             <transformers>
                                 <transformer

--- a/rain-uidgenerator-server/pom.xml
+++ b/rain-uidgenerator-server/pom.xml
@@ -16,12 +16,6 @@
     <name>rain-uidgenerator-server</name>
 
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -41,24 +35,24 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.mybatis.spring.boot</groupId>
             <artifactId>mybatis-spring-boot-starter</artifactId>
-            <version>2.2.2</version>
+            <version>4.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>druid-spring-boot-starter</artifactId>
-            <version>1.2.8</version>
+            <artifactId>druid-spring-boot-4-starter</artifactId>
+            <version>1.2.28</version>
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SegmentUidGeneratorController.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SegmentUidGeneratorController.java
@@ -6,7 +6,7 @@ import com.github.mxsm.rain.uid.core.segment.Segment;
 import com.github.mxsm.rain.uid.dto.BizCodeRegisterReqDto;
 import com.github.mxsm.rain.uid.service.AllocationService;
 import java.util.List;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/dto/BizCodeRegisterReqDto.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/dto/BizCodeRegisterReqDto.java
@@ -1,9 +1,9 @@
 package com.github.mxsm.rain.uid.dto;
 
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author mxsm

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/handler/CommonExceptionHandler.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/handler/CommonExceptionHandler.java
@@ -2,7 +2,7 @@ package com.github.mxsm.rain.uid.handler;
 
 
 import com.github.mxsm.rain.uid.core.common.Result;
-import javax.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;


### PR DESCRIPTION
## Summary

Fixes #10

Major platform and dependency upgrade to modernize the project stack.

## Changes

### Platform
- Java `11` → `25`
- Spring Boot `2.6.7` → `4.0.6`
- Maven Wrapper `3.8.4` → `3.9.15`

### Dependencies
- `mybatis-spring-boot-starter`: `2.2.2` → `4.0.0`
- `druid-spring-boot-starter` → `druid-spring-boot-4-starter`: `1.2.28`
- `mysql-connector-java` (group: `mysql`) → `mysql-connector-j` (group: `com.mysql`)
- `jmh`: `1.35` → `1.37`
- `maven-shade-plugin`: `3.2.1` → `3.6.1`
- `maven-surefire-plugin`: `3.0.0-M6` → `3.5.4`
- `httpclient5` / `httpclient5-fluent`: remove hardcoded version, managed by Spring Boot BOM

### Jakarta EE namespace migration
- `javax.validation.*` → `jakarta.validation.*` in `SegmentUidGeneratorController`, `BizCodeRegisterReqDto`, `CommonExceptionHandler`

### Build
- `maven.compiler.source`/`target` → `maven.compiler.release` (recommended for Java 9+)
- Removed redundant per-module `<properties>` blocks (now inherited from root POM)
- `spring-boot-starter-web` → `spring-boot-starter-webmvc`
- Added `maven-compiler-plugin` `annotationProcessorPaths` for JMH in `rain-uidgenerator-jmh`

### CI/CD (`.github/workflows/maven-publish.yml`)
- `actions/checkout@v2/v3` → `v4`
- `actions/setup-java@v1/v3` → `v4` with `temurin` distribution
- Java `11` → `25`
- `ubuntu-18.04` (EOL) → `ubuntu-latest`

### Tests (`UidClientTest`)
- Replaced 4 empty stub methods with real assertions
- Added `LocalSegmentUidGeneratorClient` inner class for server-free offline testing
- Tests verify consecutive ID generation, segment start values, snowflake UID parsing
