### PR TITLE
[ISSUE #14] Clock-backward wait, admin RBAC, segment backpressure, constructor injection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.idea
+**/target
+**/.flattened-pom.xml
+*.tar
+*.tar.gz
+*.zip
+HELP.md

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,8 +1,13 @@
 name: Publish package to the Maven Central Repository and GitHub Packages
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -13,10 +18,20 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+          cache: maven
+      - name: Make Maven wrapper executable
+        run: chmod +x mvnw
       - name: Verify Maven build
-        run: mvn -q -Dflatten.skip=true clean verify
+        run: ./mvnw -q -Dflatten.skip=true clean verify
       - name: Build Docker image
         run: docker build -t rain-uidgenerator:ci .
+      - name: Scan Docker image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: rain-uidgenerator:ci
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
       - name: Set up kubectl
         uses: azure/setup-kubectl@v4
       - name: Validate Kubernetes manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN chmod +x mvnw && ./mvnw -q -Dflatten.skip=true -DskipTests -pl rain-uidgener
 
 FROM eclipse-temurin:25-jre
 WORKDIR /app
-RUN addgroup --system rain && adduser --system --ingroup rain rain
+RUN groupadd --system --gid 10001 rain && \
+    useradd --system --uid 10001 --gid rain --home-dir /app --shell /usr/sbin/nologin rain
 COPY --from=build /workspace/rain-uidgenerator-server/target/rain-uidgenerator-server-*.jar /app/rain-server.jar
-USER rain
+USER 10001:10001
 EXPOSE 8080
 ENTRYPOINT ["java","-XX:MaxRAMPercentage=75","-XX:+ExitOnOutOfMemoryError","-jar","/app/rain-server.jar"]

--- a/README.md
+++ b/README.md
@@ -1,178 +1,104 @@
-# rain
+# Rain
 
-[![Publish package to the Maven Central Repository and GitHub Packages](https://github.com/mxsm/rain/actions/workflows/maven-publish.yml/badge.svg?branch=main)](https://github.com/mxsm/rain/actions/workflows/maven-publish.yml)
+Rain is a Java 25 / Spring Boot 4 distributed UID generation service. It supports two generation modes:
 
-Distributed global ID generation service, ID generation is divided into two modes：
+- Segment IDs backed by MySQL atomic allocation.
+- Snowflake IDs with deterministic worker IDs.
 
-- **segment**
-- **snowflake**
+Production guidance is in [docs/production.md](docs/production.md). API details are in [docs/api.md](docs/api.md). Java SDK usage is in [docs/sdk.md](docs/sdk.md). Chinese docs are under [docs/cn](docs/cn).
 
-How to use see the following introduction.
-
-Production deployment details are documented in [docs/production.md](docs/production.md).
-
-## Quick Start
-
-### 1. Install dependencies
+## Requirements
 
 - JDK 25
-- MySQL8
-- Maven 3.9.15
+- Maven 3.9.15, preferably through `./mvnw`
+- MySQL 8 / InnoDB
+- Docker and Kubernetes for production delivery checks
 
-### 2. Database initialization
+## Build And Test
 
-#### 2.1 Create table
-
-Run the sql script to create the database and tables：
-
-```sql
-DROP DATABASE IF EXISTS `uidgenerator`;
-CREATE DATABASE `uidgenerator` ;
-use `uidgenerator`;
-
-DROP TABLE IF EXISTS mxsm_allocation;
-CREATE TABLE `mxsm_allocation` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `biz_code` varchar(128) COLLATE utf8mb4_general_ci NOT NULL COMMENT '业务编码(用户ID,使用业务方编码)',
- `max_id` bigint NOT NULL DEFAULT '1' COMMENT '最大值',
- `step` int NOT NULL COMMENT '步长',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `biz_code_index` (`biz_code`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
-DROP TABLE IF EXISTS mxsm_snowfalke_node;
-CREATE TABLE `mxsm_snowfalke_node` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `host_name` bigint NOT NULL COMMENT 'IP地址',
- `port` int NOT NULL DEFAULT '1' COMMENT '端口',
- `deploy_env_type` enum('ACTUAL','CONTAINER') COLLATE utf8mb4_general_ci DEFAULT 'ACTUAL' COMMENT '部署环境类型',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `mix_index` (`host_name`,`port`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```bash
+java -version
+./mvnw -q -Dflatten.skip=true clean verify
+./mvnw -q -Dflatten.skip=true -DskipTests -Prelease-rain-server install
 ```
 
-## 3. rain deployment and start
+`-Dflatten.skip=true` is recommended for local verification so exploratory Maven commands do not rewrite POM files.
 
-### 3.1  Via the provided package
+## Local Run
 
-**Step 1：Download binary package**
+Create the schema through Flyway by starting the server with a MySQL database available:
 
-It can be downloaded from the [latest stable release page](https://github.com/mxsm/rain/releases)  **`rain-server-1.0.1-SNAPSHOT.tar.gz`**
+```bash
+export SPRING_PROFILES_ACTIVE=local
+export RAIN_DATASOURCE_URL='jdbc:mysql://localhost:3306/uidgenerator?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC'
+export RAIN_DATASOURCE_USERNAME=rain
+export RAIN_DATASOURCE_PASSWORD=rain
 
-```shell
-tar -zxvf rain-server-1.0.1-SNAPSHOT.tar.gz
-cd rain-server-1.0.1-SNAPSHOT/
+./mvnw -q -Dflatten.skip=true -DskipTests -pl rain-uidgenerator-server -am package
+java -jar rain-uidgenerator-server/target/rain-uidgenerator-server-1.0.1.jar
 ```
 
-**Step 2：Modify conf/application.properties**
+Register a segment business code:
 
-Modify the database-related configuration in the application.properties configuration:
-
-```properties
-spring.datasource.url=jdbc:mysql://ip:port/uidgenerator?useUnicode=true&characterEncoding=utf-8
-spring.datasource.username=xxx
-spring.datasource.password=xxxxx
+```bash
+curl -X POST http://localhost:8080/api/v1/segment/rg \
+  -H 'Content-Type: application/json' \
+  -d '{"bizCode":"orders","step":1000}'
 ```
 
-> Tips:  make sure the database address, name, port number, username, and password are correct.
+Generate IDs:
 
-**Step 3：Start server**
-
-```shell
-sh bin/start.sh
+```bash
+curl -X POST http://localhost:8080/api/v1/snowflake/uid
+curl -X POST http://localhost:8080/api/v1/segment/uid/orders
 ```
 
-![image-20220604145105893](https://raw.githubusercontent.com/mxsm/picture/main/blog/javase/jvmimage-20220604145105893.png)
+All `/api/v1/**` responses are wrapped in `Result<T>` with stable `code` values. UID generation uses POST. Legacy GET generation endpoints remain available for compatibility and return `Cache-Control: no-store`.
 
-### 4. Segment mode UID generation configuration
-
-Modify conf/application.properties
-
-| config                      | default value | explain                                                      |
-| --------------------------- | ------------- | ------------------------------------------------------------ |
-| mxsm.uid.segment.threshold  | 40            | In cache mode, when the local cache threshold is lower than or equal to 40%, the segment filling will be loaded to the database, and the value ranges from 0 to 100 |
-| mxsm.uid.segment.cache-size | 16            | Number of cached segments to load by default in cache mode   |
-
-The size of threshold and cache-size affects the frequency of segment obtained from the data. If cache-size is set too large, it will cause a waste of UID when the project is stopped for maintenance. But the cache-size is large enough that bizCode is loaded in memory before it can continue serving in the event of a database crash。
-
-### 5. Snowflake pattern UID generation configuration
-
-Modify conf/application.properties :
-
-| config                              | default value | explain                                                      |
-| ----------------------------------- | ------------- | ------------------------------------------------------------ |
-| mxsm.uid.snowflake.timestamp-bits   | 41            | The number of bits of timestamp for the snowflake algorithm  |
-| mxsm.uid.snowflake.machine-id-bits  | 10            | The number of bits in the machine id of the snowflake algorithm |
-| mxsm.uid.snowflake.sequence-bits    | 12            | The number of bits in the snowflake algorithm sequence number |
-| mxsm.uid.snowflake.container        | false         | Whether the deployment is containerized                      |
-| mxsm.uid.snowflake.time-bits-second | false         | timestamp Whether it is in seconds                           |
-| mxsm.uid.snowflake.epoch            | 2022-05-01    | timestamp The relative time in the format yyyy-MM-dd and before the current time |
-
-timestamp-bits、machine-id-bits、sequence-bits三个位数和加起来要等于63。
-
-### 6. Java SDK
-
-maven client dependence：
-
-```xml
-<dependency>
-  <groupId>com.github.mxsm</groupId>
-  <artifactId>rain-uidgenerator-client</artifactId>
-  <version>${latest version}</version>
-</dependency>
-```
-
-example:
+## Java SDK
 
 ```java
 UidClient client = UidClient.builder()
-            .setUidGeneratorServerUir("http://172.29.250.21:8080") //设置服务地址
-            .setSegmentNum(10) //设置获取的segment数量
-            .setThreshold(20) //设置阈值
-            .isSegmentUidFromRemote(false) //设置是否直接从服务器通过Restful接口的方式获取
-            .build();
-long uid = client.getSegmentUid("mxsm");
-long uidRemote = client.getSegmentUid("mxsm", true);
-long snowflake =  client.getSnowflakeUid();
+    .setUidGeneratorServerUris("http://rain-uidgenerator:8080")
+    .setToken(System.getenv("RAIN_UID_TOKEN"))
+    .setConnectTimeout(Duration.ofSeconds(1))
+    .setReadTimeout(Duration.ofSeconds(2))
+    .setMaxRetries(2)
+    .build();
+
+long id = client.getSegmentUid("orders");
 ```
 
+For local Snowflake mode the SDK no longer uses random worker IDs. Configure a stable `machineId` or Kubernetes pod ordinal:
 
-
-## Source Code Quick Start
-
-**Step 1： clone code**
-
-```shell
-git clone https://github.com/mxsm/rain.git
-cd rain
+```java
+UidClient local = UidClient.builder()
+    .isSnowflakeUidFromRemote(false)
+    .setMachineId(7)
+    .build();
 ```
 
-**Step 2：Modify application.properties in rain-uidgenerator-server**
+## Production
 
-```properties
-spring.datasource.url=jdbc:mysql://ip:port/uidgenerator?useUnicode=true&characterEncoding=utf-8
-spring.datasource.username=xxx
-spring.datasource.password=xxxxx
+Production mode expects externalized configuration:
+
+```bash
+SPRING_PROFILES_ACTIVE=prod
+RAIN_DATASOURCE_URL=jdbc:mysql://mysql-writer.example:3306/uidgenerator?useUnicode=true&characterEncoding=utf-8&useSSL=true&serverTimezone=UTC
+RAIN_DATASOURCE_USERNAME=rain
+RAIN_DATASOURCE_PASSWORD=...
+RAIN_UID_SECURITY_ENABLED=true
+RAIN_UID_TOKENS=...
+RAIN_UID_ADMIN_TOKENS=...
+RAIN_UID_SNOWFLAKE_CONTAINER=true
 ```
 
-**Step 3：maven package server**
+Kubernetes manifests are provided under [deploy/kubernetes/rain.yaml](deploy/kubernetes/rain.yaml). The StatefulSet ordinal is used as the Snowflake worker ID in production container mode.
 
-```shell
-mvn clean package -DskipTests=true
-```
+## Observability
 
-**Step 4：Start server**
+- `/actuator/health/liveness`
+- `/actuator/health/readiness`
+- `/actuator/prometheus`
 
-```shell
-java -Xms1g -Xmx1g -jar ./rain-uidgenerator-server/target/rain-uidgenerator-server-1.0.1-SNAPSHOT.jar
-```
-
-## Documentation
-
-**TODO**
+Custom metrics include UID generation counters, segment allocation latency/failures, discarded segment count, clock rollback count, and worker ID.

--- a/deploy/kubernetes/rain.yaml
+++ b/deploy/kubernetes/rain.yaml
@@ -16,6 +16,7 @@ data:
   RAIN_UID_SNOWFLAKE_CONTAINER: "true"
   RAIN_UID_SEGMENT_CACHE_SIZE: "32"
   RAIN_UID_SEGMENT_PREFETCH_THREADS: "4"
+  RAIN_UID_SEGMENT_WAIT_TIMEOUT_MS: "3000"
 ---
 apiVersion: v1
 kind: Secret
@@ -26,6 +27,23 @@ type: Opaque
 stringData:
   RAIN_DATASOURCE_PASSWORD: "change-me"
   RAIN_UID_TOKENS: "change-me"
+  RAIN_UID_ADMIN_TOKENS: "change-me-admin"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rain-uidgenerator-headless
+  namespace: rain
+  labels:
+    app: rain-uidgenerator
+spec:
+  clusterIP: None
+  selector:
+    app: rain-uidgenerator
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
 ---
 apiVersion: v1
 kind: Service
@@ -35,7 +53,7 @@ metadata:
   labels:
     app: rain-uidgenerator
 spec:
-  clusterIP: None
+  type: ClusterIP
   selector:
     app: rain-uidgenerator
   ports:
@@ -49,7 +67,7 @@ metadata:
   name: rain-uidgenerator
   namespace: rain
 spec:
-  serviceName: rain-uidgenerator
+  serviceName: rain-uidgenerator-headless
   replicas: 3
   selector:
     matchLabels:
@@ -60,9 +78,15 @@ spec:
         app: rain-uidgenerator
     spec:
       terminationGracePeriodSeconds: 35
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: rain-uidgenerator
-          image: ghcr.io/mxsm/rain:latest
+          image: ghcr.io/mxsm/rain:1.0.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -71,7 +95,12 @@ spec:
             - configMapRef:
                 name: rain-uidgenerator-config
             - secretRef:
-                name: rain-uidgenerator-secret
+              name: rain-uidgenerator-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               cpu: 250m
@@ -86,6 +115,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 2
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
@@ -93,6 +123,14 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 2
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 30
           lifecycle:
             preStop:
               exec:

--- a/distribution/conf/application-prod.yml
+++ b/distribution/conf/application-prod.yml
@@ -9,6 +9,7 @@ mxsm:
     security:
       enabled: true
       tokens: ${RAIN_UID_TOKENS}
+      admin-tokens: ${RAIN_UID_ADMIN_TOKENS}
     snowflake:
       container: true
       pod-name: ${HOSTNAME}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,108 @@
+# Rain API
+
+Base path: `/api/v1`
+
+All API responses use the same envelope:
+
+```json
+{
+  "data": 123,
+  "status": "SUCCESS",
+  "code": "SUCCESS",
+  "msg": "SUCCESS"
+}
+```
+
+Errors use the same envelope with a stable `code` and an HTTP status. Common codes:
+
+- `VALIDATION_ERROR`
+- `UNAUTHORIZED`
+- `BIZ_CODE_NOT_FOUND`
+- `SEGMENT_ALLOCATE_FAILED`
+- `UID_UNAVAILABLE`
+- `CLOCK_MOVED_BACKWARDS`
+- `WORKER_ID_UNAVAILABLE`
+- `UPSTREAM_UNAVAILABLE`
+- `INTERNAL_ERROR`
+
+## Authentication
+
+When `mxsm.uid.security.enabled=true`, send one of:
+
+```http
+Authorization: Bearer <token>
+X-API-Key: <token>
+```
+
+Generation and read endpoints accept `mxsm.uid.security.tokens` or `mxsm.uid.security.admin-tokens`. The admin endpoint `POST /api/v1/segment/rg` accepts only `admin-tokens`.
+
+`/actuator/health/**` and `/actuator/info` do not require a token.
+
+## Segment APIs
+
+### Register Biz Code
+
+```http
+POST /api/v1/segment/rg
+Content-Type: application/json
+Authorization: Bearer <admin-token>
+```
+
+```json
+{
+  "bizCode": "orders",
+  "step": 1000
+}
+```
+
+`bizCode` is limited to 128 characters. `step` must be positive.
+
+### Generate Segment UID
+
+```http
+POST /api/v1/segment/uid/{bizCode}
+Authorization: Bearer <token>
+```
+
+Legacy compatibility:
+
+```http
+GET /api/v1/segment/uid/{bizCode}
+```
+
+The GET endpoint is deprecated because ID generation has side effects. All `/api/v1/**` responses include `Cache-Control: no-store`.
+
+### Allocate Segment List
+
+```http
+GET /api/v1/segment/list/{bizCode}?segmentNum=16
+Authorization: Bearer <token>
+```
+
+This endpoint is used by the Java SDK local segment cache. `segmentNum` must be between `1` and `10000`.
+
+## Snowflake APIs
+
+### Generate Snowflake UID
+
+```http
+POST /api/v1/snowflake/uid
+Authorization: Bearer <token>
+```
+
+Legacy compatibility:
+
+```http
+GET /api/v1/snowflake/uid
+```
+
+The GET endpoint is deprecated.
+
+### Parse Snowflake UID
+
+```http
+GET /api/v1/snowflake/parse/{uid}
+Authorization: Bearer <token>
+```
+
+Returns timestamp, machine ID, and sequence.

--- a/docs/cn/rain-custom-use.md
+++ b/docs/cn/rain-custom-use.md
@@ -1,372 +1,65 @@
-### 1. Quick Start
+# Java SDK 使用说明
 
-这里介绍项目如何启动以及如何使用。clone项目到本地：
+## 远程模式
 
-```shell
-git clone https://github.com/mxsm/distributed-id-generator.git
-```
-
-### 2. 安装依赖
-
-- JDK 17
-- MySQL8
-- Maven
-
-安装好相关的依赖。
-
-#### 2.1 创建表
-
-运行一下sql脚本创建对应的数据库和表，脚本如下：
-
-```sql
-DROP DATABASE IF EXISTS `uidgenerator`;
-CREATE DATABASE `uidgenerator` ;
-use `uidgenerator`;
-
-DROP TABLE IF EXISTS mxsm_allocation;
-CREATE TABLE `mxsm_allocation` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `biz_code` varchar(128) COLLATE utf8mb4_general_ci NOT NULL COMMENT '业务编码(用户ID,使用业务方编码)',
- `max_id` bigint NOT NULL DEFAULT '1' COMMENT '最大值',
- `step` int NOT NULL COMMENT '步长',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `biz_code_index` (`biz_code`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
-DROP TABLE IF EXISTS mxsm_snowfalke_node;
-CREATE TABLE `mxsm_snowfalke_node` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `host_name` bigint NOT NULL COMMENT 'IP地址',
- `port` int NOT NULL DEFAULT '1' COMMENT '端口',
- `deploy_env_type` enum('ACTUAL','CONTAINER') COLLATE utf8mb4_general_ci DEFAULT 'ACTUAL' COMMENT '部署环境类型',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `mix_index` (`host_name`,`port`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-```
-
-修改application.properties配置中数据库相关配置：
-
-```properties
-spring.datasource.url=jdbc:mysql://ip:prot/uidgenerator?useUnicode=true&characterEncoding=utf-8
-spring.datasource.username=xxx
-spring.datasource.password=xxxxx
-```
-
-> Tips:  确保库地址, 名称, 端口号, 用户名和密码正确
-
-### 3. Segment模式UID生成配置
-
-修改配置项目uidgenerator-server中application.properties文件，以下是配置说明
-
-| 配置                        | 默认值 | 说明                                                         |
-| --------------------------- | ------ | ------------------------------------------------------------ |
-| mxsm.uid.segment.threshold  | 40     | 缓存模式下当本地缓存阈值低于或者等于40%后就会去数据库加载segment填充，取值范围0-100 |
-| mxsm.uid.segment.cache-size | 16     | 缓存模式下默认加载的缓存segment的数量                        |
-
-threshold和cache-size的大小影响从数据中获取的segment的频率，cache-size如果设置的过大在停机维护项目的时候会造成UID的浪费，但是cache-size大可以在数据库发生宕机的情况下能够继续服务之前已经加载内存中的bizCode。
-
-### 4. Snowflake模式UID生成配置
-
-修改配置项目uidgenerator-server中application.properties文件，以下是配置说明:
-
-| 配置                                | 默认值     | 说明                                                    |
-| ----------------------------------- | ---------- | ------------------------------------------------------- |
-| mxsm.uid.snowflake.timestamp-bits   | 41         | 雪花算法timestamp的位数                                 |
-| mxsm.uid.snowflake.machine-id-bits  | 10         | 雪花算法machine id的位数                                |
-| mxsm.uid.snowflake.sequence-bits    | 12         | 雪花算法序列号的位数                                    |
-| mxsm.uid.snowflake.container        | false      | 是否为容器化部署                                        |
-| mxsm.uid.snowflake.time-bits-second | false      | timestamp是否为秒                                       |
-| mxsm.uid.snowflake.epoch            | 2022-05-01 | timestamp的相对时间，格式yyyy-MM-dd，并且在当前时间以前 |
-
-timestamp-bits、machine-id-bits、sequence-bits三个位数和加起来要等于63。
-
-### 5. 启动mxsm-uidgenerator服务
-
-```shell
-cd distributed-id-generator/mxsm-uidgenerator
-mvn clean package -DskipTests=true
-java -Xms1g -Xmx1g -jar uidgenerator-server/target/uidgenerator-server-0.0.1-SNAPSHOT.jar
-```
-
-启动后：
-
-![image-20220506082523363](https://raw.githubusercontent.com/mxsm/picture/main/docs/im/DistributedIDGenerator/image-20220506082523363.png)
-
-### 6. Restful接口
-
-- **segment模式**
-  - [注册bizCode](#6.1 注册bizCode)
-  - [获取segment模式UID](#6.2 获取segment模式UID)
-  - [获取segment](#6.3 获取segment)
-- **snowflake模式**
-  - [获取snowflake模式UID](#6.4 获取snowflake模式UID)
-  - [解析snowflake的UID](#6.4 解析snowflake的UID)
-
-#### 6.1 注册bizCode
-
-**描述**
-
-> 注册bizCode对应的UID初始数据
-
-**请求类型** 
-
-> POST
-
-**请求URL**
-
-> /api/v1/segment/rg
-
-**请求body参数**
-
-| 名称    | 类型   | 是否必须 | 描述                            |
-| ------- | ------ | -------- | ------------------------------- |
-| bizCode | string | 是       | 业务编码，作为获取UID的唯一标识 |
-| step    | int    | 是       | segemt的长度                    |
-
-**返回参数**
-
-| 参数类型        | 描述         |
-| --------------- | ------------ |
-| Result<Boolean> | 注册返回结果 |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X POST '172.29.250.21:8080/api/v1/segment/rg' \
-  -H 'Content-Type: application/json' \
-  --data-raw '{
-      "bizCode":"mxsm",
-      "step":10
-  }'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": true,
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-  
-
-#### 6.2 获取segment模式UID
-
-**描述**
-
-> 获取segment模式指定bizCode的UID
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/segment/uid/{bizCode}
-
-**请求参数**
-
-| 名称    | 类型   | 是否必须 | 描述                            |
-| ------- | ------ | -------- | ------------------------------- |
-| bizCode | string | 是       | 业务编码，作为获取UID的唯一标识 |
-
-**返回参数**
-
-| 参数类型 | 描述      |
-| -------- | --------- |
-| long     | 生成的UID |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/segment/uid/l0p999zwGn4l352lxyU3OcPg19093649'
-  ```
-
-- 返回示例
-
-  ```json
-  3
-  ```
-
-#### 6.3 获取segment
-
-**描述**
-
-> 获取指定bizCode的segment
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/segment/list/{bizCode}
-
-**请求参数**
-
-| 名称       | 类型   | 是否必须 | 描述                            |
-| ---------- | ------ | -------- | ------------------------------- |
-| bizCode    | string | 是       | 业务编码，作为获取UID的唯一标识 |
-| segmentNum | int    | 是       | 获取segment的数量               |
-
-**返回参数**
-
-| 参数类型              | 描述        |
-| --------------------- | ----------- |
-| Result<List<Segment>> | segment列表 |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/segment/list/l0p999zwGn4l352lxyU3OcPg19093649?segmentNum=3'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": [
-          {
-              "segmentStartNum": 29182730,
-              "stepSize": 1006301,
-              "ok": true
-          },
-          {
-              "segmentStartNum": 30189031,
-              "stepSize": 1006301,
-              "ok": true
-          },
-          {
-              "segmentStartNum": 31195332,
-              "stepSize": 1006301,
-              "ok": true
-          }
-      ],
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-#### 6.4 获取snowflake模式UID
-
-**描述**
-
-> 获取snowflake模式下的UID
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/snowflake/uid
-
-**请求参数**
-
-无
-
-**返回参数**
-
-| 参数类型 | 描述 |
-| -------- | ---- |
-| long     | UID  |
-
-**示例：**
-
-- ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/snowflake/uid'
-  ```
-
-- 返回示例
-
-  ```json
-  1958215675834368
-  ```
-
-#### 6.4 解析snowflake的UID
-
-**描述**
-
-> 将snowflake模式下的UID解析成字符串
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/snowflake/parse/{uid}
-
-**请求参数**
-
-| 名称 | 类型 | 是否必须 | 描述                 |
-| ---- | ---- | -------- | -------------------- |
-| uid  | long | 是       | snowflake的生成的UID |
-
-**返回参数**
-
-| 参数类型 | 描述 |
-| -------- | ---- |
-| long     | UID  |
-
-**示例：**
-
-- ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/snowflake/parse/1958215675834368'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": {
-          "uid": 1958215675834368,
-          "timestamp": "2022-05-06 09:41:14",
-          "machineId": 7,
-          "sequence": 0
-      },
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-### 7. Java SDK
-
-maven坐标
-
-```xml
-<dependency>
-    <groupId>com.github.mxsm</groupId>
-    <artifactId>mxsm-uidgenerator</artifactId>
-    <version>${version}</version>
-</dependency>
-```
-
-使用例子
+远程模式是默认模式。SDK 会调用服务端接口，支持多地址轮询、失败切换、超时、有限重试、Token 和优雅关闭。
 
 ```java
 UidClient client = UidClient.builder()
-            .setUidGeneratorServerUir("http://172.29.250.21:8080") //设置服务地址
-            .setSegmentNum(10) //设置获取的segment数量
-            .setThreshold(20) //设置阈值
-            .isSegmentUidFromRemote(false) //设置是否直接从服务器通过Restful接口的方式获取
-            .build();
-long uid = client.getSegmentUid("mxsm");
-long uidRemote = client.getSegmentUid("mxsm", true);
-long snowflake =  client.getSnowflakeUid();
+    .setUidGeneratorServerUris("http://rain-uidgenerator:8080")
+    .setToken(System.getenv("RAIN_UID_TOKEN"))
+    .setConnectTimeout(Duration.ofSeconds(1))
+    .setReadTimeout(Duration.ofSeconds(2))
+    .setMaxRetries(2)
+    .build();
+
+try {
+    long segmentId = client.getSegmentUid("orders");
+    long snowflakeId = client.getSnowflakeUid();
+} finally {
+    client.shutdown();
+}
 ```
 
+`setUidGeneratorServerUir` 保留兼容但已废弃，新代码使用 `setUidGeneratorServerUris`。
+
+## Segment 本地缓存模式
+
+```java
+UidClient client = UidClient.builder()
+    .setUidGeneratorServerUris("http://rain-uidgenerator:8080")
+    .setToken(System.getenv("RAIN_UID_TOKEN"))
+    .isSegmentUidFromRemote(false)
+    .setSegmentNum(32)
+    .setThreshold(30)
+    .setPrefetchThreads(2)
+    .setSegmentWaitTimeoutMillis(3000)
+    .build();
+```
+
+本地缓存模式在进程内生成 UID，号段仍由服务端通过 MySQL 原子分配，保证全局不重叠。当本地库存耗尽且补充超时时，会抛出 `UidUnavailableException`。
+
+## Snowflake 本地模式
+
+本地 Snowflake 不再使用随机 worker id，必须使用确定性配置。
+
+显式配置：
+
+```java
+UidClient client = UidClient.builder()
+    .isSnowflakeUidFromRemote(false)
+    .setMachineId(7)
+    .build();
+```
+
+Kubernetes StatefulSet：
+
+```java
+UidClient client = UidClient.builder()
+    .isSnowflakeUidFromRemote(false)
+    .isContainer(true)
+    .setPodName(System.getenv("HOSTNAME"))
+    .build();
+```
+
+`machineId` 必须在 `machineIdBits` 允许范围内，配置缺失或越界会快速失败。

--- a/docs/cn/rain-custom.md
+++ b/docs/cn/rain-custom.md
@@ -1,112 +1,84 @@
-### 1. 背景
+# Rain 生产配置
 
-为什么要自己设计一个分布式ID生成器？这个主要是用于生成IM消息的ID。IM消息有个特点跟用户结合比较紧密，单聊是跟用户相关，群聊是跟群相关。进一步分析群聊的群也可以看做一个特殊的用户，所以分布式ID生成器一个条件就是以人作为区分纬度。同时也需要兼顾业务类型的ID生成。
+Rain 当前基于 Java 25 和 Spring Boot 4。生产部署建议使用 Kubernetes StatefulSet + 外部 MySQL 8 高可用写端点。
 
-### 2.分布式ID要求
+## 必需环境变量
 
-#### 2.1 业务要求
-
-- 支持以用户为纬度生成全局ID,对于一个用户在分布式ID生成器中生成的ID是唯一的
-- 支持以业务作为纬度生成全局ID,例如电商业务，仓储业务。
-- 支持生成全局ID,以使用者为纬度。
-
-#### 2.2 性能要求
-
-- 支持客户端本地生成，就算服务端在使用过程中宕机不可用，在一段时间内不影响本地ID的生成
-- 支持HTTP模式获取生成ID
-- 支持容器化部署
-- 支持每秒百万ID生成
-
-### 3. rain实现
-
-为了实现上面的业务需求以及性能要求，提供了segment和snowflake两种模式
-
-#### 3.1 segment模式
-
-segment模式使用的数据库方案，数据库表设计如下：
-
-```sql
-CREATE TABLE `mxsm_allocation` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `biz_code` varchar(128) COLLATE utf8mb4_general_ci NOT NULL COMMENT '业务编码(用户ID,使用业务方编码)',
- `max_id` bigint NOT NULL DEFAULT '1' COMMENT '最大值',
- `step` int NOT NULL COMMENT '步长',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `biz_code_index` (`biz_code`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```bash
+SPRING_PROFILES_ACTIVE=prod
+RAIN_DATASOURCE_URL=jdbc:mysql://mysql-writer.example:3306/uidgenerator?useUnicode=true&characterEncoding=utf-8&useSSL=true&serverTimezone=UTC
+RAIN_DATASOURCE_USERNAME=rain
+RAIN_DATASOURCE_PASSWORD=...
+RAIN_UID_SECURITY_ENABLED=true
+RAIN_UID_TOKENS=...
+RAIN_UID_ADMIN_TOKENS=...
+RAIN_UID_SNOWFLAKE_CONTAINER=true
 ```
 
-根据biz_code从数据库中获取对应的分配信息，然后在内存中生成ID。每一个biz_code的ID生成是相互隔离的。例如biz_code的编码为mxsm，step = 100,那么获取的生成ID的号段为：1-101，当消耗完成从数据库中根据如下SQL继续加载：
+## Segment 配置
 
-```sql
-begin;
-SELECT id, max_id as maxId, step FROM mxsm_allocation WHERE biz_code = #{bizCode} FOR UPDATE;
-UPDATE mxsm_allocation SET max_id = max_id + step WHERE  biz_code = #{bizCode}
-commit;
+```bash
+RAIN_UID_SEGMENT_CACHE_SIZE=32
+RAIN_UID_SEGMENT_THRESHOLD=40
+RAIN_UID_SEGMENT_PREFETCH_THREADS=4
+RAIN_UID_SEGMENT_WAIT_TIMEOUT_MS=3000
 ```
 
-为了提高生成的并发以及效率，可以一次性加载多个号段到内存中，当内存中的的号段消耗了，剩余的号段低于设置的阈值，然后去数据库获取消耗的数量的号段填充到缓存中：
+说明：
 
-![https://www.liuchengtu.com/lct/#X9f51cc114a7edcae9f46b07cb799e2e2](https://raw.githubusercontent.com/mxsm/picture/main/docs/im/DistributedIDGenerator/%E5%88%86%E6%AE%B5%E6%A8%A1%E5%BC%8F%E7%BC%93%E5%AD%98%E7%94%9F%E6%88%90.png)
+- `cache-size`：本地缓存的号段数量。
+- `threshold`：库存百分比低于阈值时触发预取。
+- `prefetch-threads`：后台补充号段线程数。
+- `wait-timeout-millis`：库存耗尽时等待补充号段的最长时间。
 
-对于mxsm_allocation表的数量过大，可以采用分库分表，通过预测公司的biz_code数量来判断分库分表。力度最小就是以用户作为单位进行分库分表如果以公司有20亿用户来计算(这个已经算是很大了)，单表2000w数据，那么就需要部署100台数据库服务。大部分公司以单表2000w数据，部署3-5台基本上能够全部满足。
+## Snowflake 配置
 
-![分布式ID生成器-分段模式](https://raw.githubusercontent.com/mxsm/picture/main/docs/im/DistributedIDGenerator/%E5%88%86%E5%B8%83%E5%BC%8FID%E7%94%9F%E6%88%90%E5%99%A8-%E5%88%86%E6%AE%B5%E6%A8%A1%E5%BC%8F.png)
-
-**分段式分布式ID生成器的优点：**
-
-- segment模式可以很方便的进行线性拓展，性能能够支持绝大部分场景
-- 生成的ID在biz_code趋势递增。
-- 有很好的容灾性，对于客户端模式即使服务器发生宕机，在一定时间内客户端还是可以提供ID生成，如果数据库宕机，由于生成ID的服务内部存在缓存，在一定时间内还能对外正常的提供服务。(服务时间长短取决于消耗ID的数据和换成的大小)
-
-**分段式分布式ID生成器的缺点：**
-
-- ID不够随机，对于用作订单号会让人估算出订单数量，但是如果用在消息ID这个就可以
-- 数据库宕机会导致服务一段时间过后不能使用。依赖数据库。
-- segment缓存设置的太大或者step设置太大如果服务宕机或者重启会造成浪费。
-
-#### 3.2 snowflake模式
-
-雪花算法的位图结构如下：
-
-![雪花算法ID的结构](https://raw.githubusercontent.com/mxsm/picture/main/docs/im/DistributedIDGenerator/%E9%9B%AA%E8%8A%B1%E7%AE%97%E6%B3%95ID%E7%9A%84%E7%BB%93%E6%9E%84.png)
-
-雪花算法是趋势递增的ID生成方案。由于snowflake方案的bit位设计，即是“1+41+10+12”的方式组装ID号，时间戳使用的是毫秒，且其他的位数都固定。这里提供了调整时间戳、机器ID、序列号的位数。以及时间戳单位是秒还是毫秒的解决方案(方案参考[uid-generator](https://github.com/baidu/uid-generator)设计)。同时对于机器ID,每次服务启动将IP和port存入数据库，以主键ID作为机器号。如果是用标准的雪花算法最多能部署1024台机器。
-
-```sql
-CREATE TABLE `mxsm_snowfalke_node` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `host_name` bigint NOT NULL COMMENT 'IP地址',
- `port` int NOT NULL DEFAULT '1' COMMENT '端口',
- `deploy_env_type` enum('ACTUAL','CONTAINER') COLLATE utf8mb4_general_ci DEFAULT 'ACTUAL' COMMENT '部署环境类型',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `mix_index` (`host_name`,`port`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```bash
+RAIN_UID_SNOWFLAKE_TIMESTAMP_BITS=41
+RAIN_UID_SNOWFLAKE_MACHINE_ID_BITS=10
+RAIN_UID_SNOWFLAKE_SEQUENCE_BITS=12
+RAIN_UID_SNOWFLAKE_EPOCH=2022-05-01
+RAIN_UID_SNOWFLAKE_MAX_BACKWARD_MILLIS=1000
 ```
 
-**时间回拨解决：**
+生产 Kubernetes 模式默认从 StatefulSet pod 名称解析 ordinal 作为 worker id，例如 `rain-uidgenerator-2` 的 worker id 为 `2`。解析失败或超出 bit 范围时应用会失败，不会随机降级。
 
-- 在服务器时间回拨1S内，通过等待实现时间同步
-- 如果超过设置的1s，直接报错生产ID失败
+## 数据库
 
-**雪花算法位数长度可修改变动好处：**
+Flyway 迁移位于：
 
-- 在机器能够满足调用的情况下，可以小机器的ID的位数，增加序列号来提高单位时间内生成的最大数量。可以根据个人的需求进行调整。
-- 时间戳的单位是毫秒还是秒，这个能够决定当前服务使用的长短。
+```text
+rain-uidgenerator-server/src/main/resources/db/migration
+```
 
-**客户端本地生成ID: **
+号段分配使用 MySQL 原子更新：
 
-将雪花算法集成到客户端，机器ID在机器Bits位数的最大值和最小值中随机生成一个。好处：能够在本地生成ID，无网络的消耗、并发高。缺点：如果随机生成的机器ID重复的数量太多。并且高并发生成的情况下会出现ID重复的情况。不适合全局唯一的情况。
+```sql
+UPDATE mxsm_allocation
+SET max_id = LAST_INSERT_ID(max_id + step * ?)
+WHERE biz_code = ?;
+SELECT LAST_INSERT_ID();
+```
 
-> Tips: 本地通过雪花算法随机机器ID生成UID的方式，笔者公司就在使用。重复ID的概率比较低，毕竟需要同一个业务中的同一张表的ID一样。
+该模式支持多实例并发分配且号段不重叠。
 
-### 4. 总结
+## 观测
 
-- segment+本地Cache的模式实现了搞并发和搞可用，即使数据库不可用也不会让服务对外立马不可用。
-- snowflake模式对位数的调整，能够满足绝大部分人的需要，高并发以及服务可用时间长短。
+健康检查：
+
+- `/actuator/health/liveness`
+- `/actuator/health/readiness`
+
+Prometheus：
+
+- `/actuator/prometheus`
+
+重点指标：
+
+- `rain_uid_segment_generated_total`
+- `rain_uid_snowflake_generated_total`
+- `rain_uid_segment_allocation_duration`
+- `rain_uid_segment_allocation_failed_total`
+- `rain_uid_segment_discarded_total`
+- `rain_uid_snowflake_clock_rollback_total`
+- `rain_uid_snowflake_worker_id`

--- a/docs/cn/rain-restful.md
+++ b/docs/cn/rain-restful.md
@@ -1,375 +1,87 @@
-# rain
+# Rain REST API
 
-[![Publish package to the Maven Central Repository and GitHub Packages](https://github.com/mxsm/rain/actions/workflows/maven-publish.yml/badge.svg?branch=main)](https://github.com/mxsm/rain/actions/workflows/maven-publish.yml)
+基础路径：`/api/v1`
 
-分布式全局ID生成服务，ID生成分为两个模式：
+所有接口返回统一结构：
 
-- **segment（分段模式）**
-- **snowflake（雪花算法）**
-
-如何使用看如下介绍。
-
-### 1. Quick Start
-
-这里介绍项目如何启动以及如何使用。clone项目到本地：
-
-```shell
-git clone https://github.com/mxsm/rain.git
+```json
+{
+  "data": 123,
+  "status": "SUCCESS",
+  "code": "SUCCESS",
+  "msg": "SUCCESS"
+}
 ```
 
-### 2. 安装依赖
+错误也使用同样结构，`code` 为稳定错误码，例如 `VALIDATION_ERROR`、`UNAUTHORIZED`、`BIZ_CODE_NOT_FOUND`、`UID_UNAVAILABLE`、`CLOCK_MOVED_BACKWARDS`。
 
-- JDK 11
-- MySQL8
-- Maven
+## 鉴权
 
-安装好相关的依赖。
+生产开启：
 
-#### 2.1 创建表
-
-运行一下sql脚本创建对应的数据库和表，脚本如下：
-
-```sql
-DROP DATABASE IF EXISTS `uidgenerator`;
-CREATE DATABASE `uidgenerator` ;
-use `uidgenerator`;
-
-DROP TABLE IF EXISTS mxsm_allocation;
-CREATE TABLE `mxsm_allocation` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `biz_code` varchar(128) COLLATE utf8mb4_general_ci NOT NULL COMMENT '业务编码(用户ID,使用业务方编码)',
- `max_id` bigint NOT NULL DEFAULT '1' COMMENT '最大值',
- `step` int NOT NULL COMMENT '步长',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `biz_code_index` (`biz_code`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
-DROP TABLE IF EXISTS mxsm_snowfalke_node;
-CREATE TABLE `mxsm_snowfalke_node` (
- `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
- `host_name` bigint NOT NULL COMMENT 'IP地址',
- `port` int NOT NULL DEFAULT '1' COMMENT '端口',
- `deploy_env_type` enum('ACTUAL','CONTAINER') COLLATE utf8mb4_general_ci DEFAULT 'ACTUAL' COMMENT '部署环境类型',
- `description` varchar(255) COLLATE utf8mb4_general_ci DEFAULT '' COMMENT '说明',
- `create_time` timestamp NOT NULL COMMENT '创建时间',
- `update_time` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
- PRIMARY KEY (`id`),
- UNIQUE KEY `mix_index` (`host_name`,`port`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```yaml
+mxsm.uid.security.enabled: true
+mxsm.uid.security.tokens: ${RAIN_UID_TOKENS}
+mxsm.uid.security.admin-tokens: ${RAIN_UID_ADMIN_TOKENS}
 ```
 
-修改application.properties配置中数据库相关配置：
+请求头：
 
-```properties
-spring.datasource.url=jdbc:mysql://ip:prot/uidgenerator?useUnicode=true&characterEncoding=utf-8
-spring.datasource.username=xxx
-spring.datasource.password=xxxxx
+```http
+Authorization: Bearer <token>
 ```
 
-> Tips:  确保库地址, 名称, 端口号, 用户名和密码正确
+或：
 
-### 3. Segment模式UID生成配置
-
-修改配置项目uidgenerator-server中application.properties文件，以下是配置说明
-
-| 配置                        | 默认值 | 说明                                                         |
-| --------------------------- | ------ | ------------------------------------------------------------ |
-| mxsm.uid.segment.threshold  | 40     | 缓存模式下当本地缓存阈值低于或者等于40%后就会去数据库加载segment填充，取值范围0-100 |
-| mxsm.uid.segment.cache-size | 16     | 缓存模式下默认加载的缓存segment的数量                        |
-
-threshold和cache-size的大小影响从数据中获取的segment的频率，cache-size如果设置的过大在停机维护项目的时候会造成UID的浪费，但是cache-size大可以在数据库发生宕机的情况下能够继续服务之前已经加载内存中的bizCode。
-
-### 4. Snowflake模式UID生成配置
-
-修改配置项目uidgenerator-server中application.properties文件，以下是配置说明:
-
-| 配置                                | 默认值     | 说明                                                    |
-| ----------------------------------- | ---------- | ------------------------------------------------------- |
-| mxsm.uid.snowflake.timestamp-bits   | 41         | 雪花算法timestamp的位数                                 |
-| mxsm.uid.snowflake.machine-id-bits  | 10         | 雪花算法machine id的位数                                |
-| mxsm.uid.snowflake.sequence-bits    | 12         | 雪花算法序列号的位数                                    |
-| mxsm.uid.snowflake.container        | false      | 是否为容器化部署                                        |
-| mxsm.uid.snowflake.time-bits-second | false      | timestamp是否为秒                                       |
-| mxsm.uid.snowflake.epoch            | 2022-05-01 | timestamp的相对时间，格式yyyy-MM-dd，并且在当前时间以前 |
-
-timestamp-bits、machine-id-bits、sequence-bits三个位数和加起来要等于63。
-
-### 5. 启动mxsm-uidgenerator服务
-
-```shell
-cd distributed-id-generator/mxsm-uidgenerator
-mvn clean package -DskipTests=true
-java -Xms1g -Xmx1g -jar uidgenerator-server/target/uidgenerator-server-0.0.1-SNAPSHOT.jar
+```http
+X-API-Key: <token>
 ```
 
-启动后：
+普通生成接口接受 `tokens` 或 `admin-tokens`。管理接口 `POST /api/v1/segment/rg` 只接受 `admin-tokens`。
 
-![image-20220506082523363](https://raw.githubusercontent.com/mxsm/picture/main/docs/im/DistributedIDGenerator/image-20220506082523363.png)
+## Segment
 
-### 6. Restful接口
+注册业务编码：
 
-#### 6.1 注册bizCode
-
-**描述**
-
-> 注册bizCode对应的UID初始数据
-
-**请求类型** 
-
-> POST
-
-**请求URL**
-
-> /api/v1/segment/rg
-
-**请求body参数**
-
-| 名称    | 类型   | 是否必须 | 描述                            |
-| ------- | ------ | -------- | ------------------------------- |
-| bizCode | string | 是       | 业务编码，作为获取UID的唯一标识 |
-| step    | int    | 是       | segemt的长度                    |
-
-**返回参数**
-
-| 参数类型        | 描述         |
-| --------------- | ------------ |
-| Result<Boolean> | 注册返回结果 |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X POST '172.29.250.21:8080/api/v1/segment/rg' \
+```bash
+curl -X POST http://localhost:8080/api/v1/segment/rg \
   -H 'Content-Type: application/json' \
-  --data-raw '{
-      "bizCode":"mxsm",
-      "step":10
-  }'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": true,
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-  
-
-#### 6.2 获取segment模式UID
-
-**描述**
-
-> 获取segment模式指定bizCode的UID
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/segment/uid/{bizCode}
-
-**请求参数**
-
-| 名称    | 类型   | 是否必须 | 描述                            |
-| ------- | ------ | -------- | ------------------------------- |
-| bizCode | string | 是       | 业务编码，作为获取UID的唯一标识 |
-
-**返回参数**
-
-| 参数类型 | 描述      |
-| -------- | --------- |
-| long     | 生成的UID |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/segment/uid/l0p999zwGn4l352lxyU3OcPg19093649'
-  ```
-
-- 返回示例
-
-  ```json
-  3
-  ```
-
-#### 6.3 获取segment
-
-**描述**
-
-> 获取指定bizCode的segment
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/segment/list/{bizCode}
-
-**请求参数**
-
-| 名称       | 类型   | 是否必须 | 描述                            |
-| ---------- | ------ | -------- | ------------------------------- |
-| bizCode    | string | 是       | 业务编码，作为获取UID的唯一标识 |
-| segmentNum | int    | 是       | 获取segment的数量               |
-
-**返回参数**
-
-| 参数类型              | 描述        |
-| --------------------- | ----------- |
-| Result<List<Segment>> | segment列表 |
-
-**示例：**
-
-- 请求示例
-
-  ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/segment/list/l0p999zwGn4l352lxyU3OcPg19093649?segmentNum=3'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": [
-          {
-              "segmentStartNum": 29182730,
-              "stepSize": 1006301,
-              "ok": true
-          },
-          {
-              "segmentStartNum": 30189031,
-              "stepSize": 1006301,
-              "ok": true
-          },
-          {
-              "segmentStartNum": 31195332,
-              "stepSize": 1006301,
-              "ok": true
-          }
-      ],
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-#### 6.4 获取snowflake模式UID
-
-**描述**
-
-> 获取snowflake模式下的UID
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/snowflake/uid
-
-**请求参数**
-
-无
-
-**返回参数**
-
-| 参数类型 | 描述 |
-| -------- | ---- |
-| long     | UID  |
-
-**示例：**
-
-- ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/snowflake/uid'
-  ```
-
-- 返回示例
-
-  ```json
-  1958215675834368
-  ```
-
-#### 6.4 解析snowflake的UID
-
-**描述**
-
-> 将snowflake模式下的UID解析成字符串
-
-**请求类型** 
-
-> GET
-
-**请求URL**
-
-> /api/v1/snowflake/parse/{uid}
-
-**请求参数**
-
-| 名称 | 类型 | 是否必须 | 描述                 |
-| ---- | ---- | -------- | -------------------- |
-| uid  | long | 是       | snowflake的生成的UID |
-
-**返回参数**
-
-| 参数类型 | 描述 |
-| -------- | ---- |
-| long     | UID  |
-
-**示例：**
-
-- ```shell
-  curl -L -X GET '172.29.250.21:8080/api/v1/snowflake/parse/1958215675834368'
-  ```
-
-- 返回示例
-
-  ```json
-  {
-      "data": {
-          "uid": 1958215675834368,
-          "timestamp": "2022-05-06 09:41:14",
-          "machineId": 7,
-          "sequence": 0
-      },
-      "status": "SUCCESS",
-      "msg": "SUCCESS"
-  }
-  ```
-
-### 7. Java SDK
-
-maven坐标
-
-```xml
-<dependency>
-    <groupId>com.github.mxsm</groupId>
-    <artifactId>mxsm-uidgenerator</artifactId>
-    <version>${version}</version>
-</dependency>
+  -H "Authorization: Bearer ${RAIN_ADMIN_TOKEN}" \
+  -d '{"bizCode":"orders","step":1000}'
 ```
 
-使用例子
+生成 UID：
 
-```java
-UidClient client = UidClient.builder()
-            .setUidGeneratorServerUir("http://172.29.250.21:8080") //设置服务地址
-            .setSegmentNum(10) //设置获取的segment数量
-            .setThreshold(20) //设置阈值
-            .isSegmentUidFromRemote(false) //设置是否直接从服务器通过Restful接口的方式获取
-            .build();
-long uid = client.getSegmentUid("mxsm");
-long uidRemote = client.getSegmentUid("mxsm", true);
-long snowflake =  client.getSnowflakeUid();
+```bash
+curl -X POST http://localhost:8080/api/v1/segment/uid/orders \
+  -H "Authorization: Bearer ${RAIN_TOKEN}"
 ```
 
+批量获取号段，供 SDK 本地缓存使用：
+
+```bash
+curl 'http://localhost:8080/api/v1/segment/list/orders?segmentNum=16' \
+  -H "Authorization: Bearer ${RAIN_TOKEN}"
+```
+
+## Snowflake
+
+生成 UID：
+
+```bash
+curl -X POST http://localhost:8080/api/v1/snowflake/uid \
+  -H "Authorization: Bearer ${RAIN_TOKEN}"
+```
+
+解析 UID：
+
+```bash
+curl http://localhost:8080/api/v1/snowflake/parse/{uid} \
+  -H "Authorization: Bearer ${RAIN_TOKEN}"
+```
+
+## GET 兼容接口
+
+旧版 GET 生成接口仍保留，但已废弃。生成 UID 是有副作用的操作，新接入方应使用 POST。
+
+所有 `/api/v1/**` 响应都会带 `Cache-Control: no-store`。

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,13 +1,12 @@
 # Production Deployment
 
-Rain is designed to run as multiple stateless service replicas backed by a highly available MySQL 8 writer endpoint.
+Rain is intended to run as multiple stateless Java service replicas backed by a highly available MySQL 8 writer endpoint. No Redis or service registry is required.
 
-## Runtime Requirements
+## Runtime Model
 
-- Java 25
-- MySQL 8 / InnoDB
-- Kubernetes for production Snowflake worker id stability
-- Externalized secrets through environment variables or Kubernetes Secrets
+- Segment mode stores allocation state in MySQL and uses atomic `LAST_INSERT_ID(max_id + step * segmentNum)` updates.
+- Snowflake mode uses a deterministic worker ID. In Kubernetes production deployment, the StatefulSet pod ordinal is the worker ID.
+- Service replicas can scale horizontally as long as the replica count is within the configured `machine-id-bits` range.
 
 ## Required Environment
 
@@ -18,25 +17,80 @@ RAIN_DATASOURCE_USERNAME=rain
 RAIN_DATASOURCE_PASSWORD=...
 RAIN_UID_SECURITY_ENABLED=true
 RAIN_UID_TOKENS=...
+RAIN_UID_ADMIN_TOKENS=...
 RAIN_UID_SNOWFLAKE_CONTAINER=true
 ```
 
-For Kubernetes, deploy `deploy/kubernetes/rain.yaml` as a starting point. The `StatefulSet` pod ordinal is used as the Snowflake machine id, so keep the replica count within the configured machine-id bit range.
+Useful tuning variables:
 
-## APIs
-
-All `/api/v1/**` success responses are wrapped:
-
-```json
-{
-  "data": 123,
-  "status": "SUCCESS",
-  "code": "SUCCESS",
-  "msg": "SUCCESS"
-}
+```bash
+RAIN_DATASOURCE_MAX_POOL_SIZE=20
+RAIN_DATASOURCE_MIN_IDLE=4
+RAIN_DATASOURCE_CONNECTION_TIMEOUT_MS=3000
+RAIN_UID_SEGMENT_CACHE_SIZE=32
+RAIN_UID_SEGMENT_THRESHOLD=40
+RAIN_UID_SEGMENT_PREFETCH_THREADS=4
+RAIN_UID_SEGMENT_WAIT_TIMEOUT_MS=3000
+RAIN_UID_SNOWFLAKE_MAX_BACKWARD_MILLIS=1000
 ```
 
-Errors use the same envelope with stable `code` values and HTTP status codes.
+## Security
+
+Enable token authentication in production:
+
+- `RAIN_UID_TOKENS`: generation/read tokens.
+- `RAIN_UID_ADMIN_TOKENS`: admin tokens. Required for `POST /api/v1/segment/rg`.
+
+Do not store real secrets in Kubernetes manifests. Use External Secrets, Sealed Secrets, your cloud secret manager, or manually created Kubernetes Secrets.
+
+## Kubernetes
+
+Start from [deploy/kubernetes/rain.yaml](../deploy/kubernetes/rain.yaml).
+
+The manifest includes:
+
+- Namespace
+- ConfigMap
+- Secret placeholder
+- Headless Service for StatefulSet identity
+- ClusterIP Service for normal clients
+- StatefulSet
+- readiness/liveness/startup probes
+- PodDisruptionBudget
+- HorizontalPodAutoscaler
+- NetworkPolicy
+
+Important production adjustments:
+
+- Replace `ghcr.io/mxsm/rain:1.0.1` with your immutable image tag or digest.
+- Replace `change-me` secret placeholders.
+- Adjust NetworkPolicy egress for your MySQL writer endpoint.
+- Keep `replicas <= 2^machineIdBits - 1`.
+- Use PodAntiAffinity or topology spread constraints if your cluster spans zones.
+
+## Database
+
+Flyway migrations live in:
+
+```text
+rain-uidgenerator-server/src/main/resources/db/migration
+```
+
+The first migration creates:
+
+- `mxsm_allocation`
+- `mxsm_snowfalke_node`
+
+For production, grant the application user only the permissions it needs for these tables and Flyway migration execution. The legacy [scripts/mxsm-uidgenerator.sql](../scripts/mxsm-uidgenerator.sql) is kept for local bootstrap and no longer drops databases or tables.
+
+## API Compatibility
+
+UID generation should use POST:
+
+- `POST /api/v1/segment/uid/{bizCode}`
+- `POST /api/v1/snowflake/uid`
+
+Legacy GET endpoints remain available for compatibility but are deprecated. All `/api/v1/**` responses include `Cache-Control: no-store`.
 
 ## Observability
 
@@ -46,8 +100,44 @@ Actuator endpoints:
 - `/actuator/health/readiness`
 - `/actuator/prometheus`
 
-Custom metrics include segment generation, Snowflake generation, segment allocation latency/failures, clock rollback count, and worker id.
+Custom metrics:
 
-## Database
+- `rain_uid_segment_generated_total`
+- `rain_uid_snowflake_generated_total`
+- `rain_uid_segment_allocation_duration`
+- `rain_uid_segment_allocation_failed_total`
+- `rain_uid_segment_discarded_total`
+- `rain_uid_snowflake_clock_rollback_total`
+- `rain_uid_snowflake_worker_id`
 
-Flyway applies schema migrations from `rain-uidgenerator-server/src/main/resources/db/migration`. The legacy `scripts/mxsm-uidgenerator.sql` is safe for local bootstrap and does not drop existing databases or tables.
+Recommended alerts:
+
+- Readiness failures > 0 for more than 2 minutes.
+- Segment allocation failures > 0.
+- Segment discarded count > 0.
+- Clock rollback count > 0.
+- MySQL connection pool saturation.
+- HTTP 5xx rate above baseline.
+
+## Rollout And Rollback
+
+Use rolling deployment for normal backward-compatible releases. For risky changes, use canary traffic through your ingress/service mesh.
+
+Rollback checklist:
+
+- Previous image tag/digest is available.
+- Flyway migration is backward-compatible.
+- MySQL writer endpoint is healthy.
+- Prometheus and logs are available during rollout.
+
+## Verification
+
+```bash
+java -version
+./mvnw -q -Dflatten.skip=true clean verify
+./mvnw -q -Dflatten.skip=true -DskipTests -Prelease-rain-server install
+docker build -t rain-uidgenerator:ci .
+kubectl apply --dry-run=client --validate=false -f deploy/kubernetes/rain.yaml
+```
+
+Testcontainers MySQL integration tests run automatically when Docker is available.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,90 @@
+# Java SDK
+
+Dependency:
+
+```xml
+<dependency>
+  <groupId>com.github.mxsm</groupId>
+  <artifactId>rain-uidgenerator-client</artifactId>
+  <version>1.0.1</version>
+</dependency>
+```
+
+## Remote Mode
+
+Remote mode is the default. The SDK calls Rain server APIs and supports endpoint round-robin, failure failover, timeouts, finite retries, token headers, and graceful shutdown.
+
+```java
+import com.github.mxsm.rain.uid.client.UidClient;
+import java.time.Duration;
+
+UidClient client = UidClient.builder()
+    .setUidGeneratorServerUris(
+        "http://rain-uidgenerator-0.rain-uidgenerator-headless:8080",
+        "http://rain-uidgenerator-1.rain-uidgenerator-headless:8080",
+        "http://rain-uidgenerator-2.rain-uidgenerator-headless:8080")
+    .setToken(System.getenv("RAIN_UID_TOKEN"))
+    .setConnectTimeout(Duration.ofSeconds(1))
+    .setReadTimeout(Duration.ofSeconds(2))
+    .setMaxRetries(2)
+    .setRetryBackoff(Duration.ofMillis(50))
+    .setFailurePenalty(Duration.ofSeconds(1))
+    .build();
+
+try {
+    long segmentId = client.getSegmentUid("orders");
+    long snowflakeId = client.getSnowflakeUid();
+} finally {
+    client.shutdown();
+}
+```
+
+`setUidGeneratorServerUir` is kept for compatibility but is deprecated. Use `setUidGeneratorServerUris`.
+
+## Local Segment Cache
+
+Local segment mode fetches batches from the server and generates IDs in-process:
+
+```java
+UidClient client = UidClient.builder()
+    .setUidGeneratorServerUris("http://rain-uidgenerator:8080")
+    .setToken(System.getenv("RAIN_UID_TOKEN"))
+    .isSegmentUidFromRemote(false)
+    .setSegmentNum(32)
+    .setThreshold(30)
+    .setPrefetchThreads(2)
+    .setSegmentWaitTimeoutMillis(3000)
+    .build();
+```
+
+This mode reduces request latency while MySQL allocation still remains globally atomic. If all local segments are exhausted and refill does not arrive before `segmentWaitTimeoutMillis`, the SDK throws `UidUnavailableException`.
+
+## Local Snowflake Mode
+
+Local Snowflake mode no longer uses random worker IDs. Configure one deterministic source.
+
+Explicit machine ID:
+
+```java
+UidClient client = UidClient.builder()
+    .isSnowflakeUidFromRemote(false)
+    .setMachineId(7)
+    .setMaxBackwardMillis(1000)
+    .build();
+```
+
+Kubernetes StatefulSet pod ordinal:
+
+```java
+UidClient client = UidClient.builder()
+    .isSnowflakeUidFromRemote(false)
+    .isContainer(true)
+    .setPodName(System.getenv("HOSTNAME"))
+    .build();
+```
+
+The worker ID must be within the configured `machineIdBits` range. Invalid or missing worker IDs fail fast.
+
+## Error Handling
+
+Server-side failures are converted to `UidGenerateException` or `UidUnavailableException`. Remote server error envelopes are parsed with Jackson, not fastjson.

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <testcontainers.version>2.0.5</testcontainers.version>
         <revision>1.0.1</revision>
         <maven.flatten.version>1.2.5</maven.flatten.version>
+        <maven.enforcer.version>3.5.0</maven.enforcer.version>
     </properties>
 
     <dependencyManagement>
@@ -151,6 +152,29 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-runtime</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[25,26)</version>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>[3.9.0,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/Config.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/Config.java
@@ -23,13 +23,27 @@ public class Config {
 
     private String token;
 
+    private Long machineId;
+
+    private boolean container;
+
+    private String podName;
+
+    private long maxBackwardMillis = 1000L;
+
     private Duration connectTimeout = Duration.ofSeconds(3);
 
     private Duration readTimeout = Duration.ofSeconds(5);
 
     private int maxRetries = 1;
 
+    private Duration retryBackoff = Duration.ofMillis(50);
+
+    private Duration failurePenalty = Duration.ofSeconds(1);
+
     private int prefetchThreads = 2;
+
+    private long segmentWaitTimeoutMillis = 3000L;
 
     //get segment number from remote server
     private int segmentNum = 16;
@@ -160,6 +174,38 @@ public class Config {
         this.token = token;
     }
 
+    public Long getMachineId() {
+        return machineId;
+    }
+
+    public void setMachineId(Long machineId) {
+        this.machineId = machineId;
+    }
+
+    public boolean isContainer() {
+        return container;
+    }
+
+    public void setContainer(boolean container) {
+        this.container = container;
+    }
+
+    public String getPodName() {
+        return podName;
+    }
+
+    public void setPodName(String podName) {
+        this.podName = podName;
+    }
+
+    public long getMaxBackwardMillis() {
+        return maxBackwardMillis;
+    }
+
+    public void setMaxBackwardMillis(long maxBackwardMillis) {
+        this.maxBackwardMillis = maxBackwardMillis;
+    }
+
     public Duration getConnectTimeout() {
         return connectTimeout;
     }
@@ -184,12 +230,36 @@ public class Config {
         this.maxRetries = maxRetries;
     }
 
+    public Duration getRetryBackoff() {
+        return retryBackoff;
+    }
+
+    public void setRetryBackoff(Duration retryBackoff) {
+        this.retryBackoff = retryBackoff;
+    }
+
+    public Duration getFailurePenalty() {
+        return failurePenalty;
+    }
+
+    public void setFailurePenalty(Duration failurePenalty) {
+        this.failurePenalty = failurePenalty;
+    }
+
     public int getPrefetchThreads() {
         return prefetchThreads;
     }
 
     public void setPrefetchThreads(int prefetchThreads) {
         this.prefetchThreads = prefetchThreads;
+    }
+
+    public long getSegmentWaitTimeoutMillis() {
+        return segmentWaitTimeoutMillis;
+    }
+
+    public void setSegmentWaitTimeoutMillis(long segmentWaitTimeoutMillis) {
+        this.segmentWaitTimeoutMillis = segmentWaitTimeoutMillis;
     }
 
     public boolean isSnowflakeUidFromRemote() {

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/Http2Requester.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/Http2Requester.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Shared HTTP/2-capable requester with endpoint failover.
@@ -20,6 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Http2Requester {
 
     private static final Map<Duration, HttpClient> CLIENTS = new ConcurrentHashMap<>();
+
+    private static final Map<URI, AtomicLong> UNHEALTHY_UNTIL_NANOS = new ConcurrentHashMap<>();
 
     private Http2Requester() {
     }
@@ -29,6 +32,14 @@ public class Http2Requester {
     }
 
     public static String executeGET(Config config, String path, Map<String, String> params) {
+        return execute(config, "GET", path, params);
+    }
+
+    public static String executePOST(Config config, String path) {
+        return execute(config, "POST", path, null);
+    }
+
+    private static String execute(Config config, String method, String path, Map<String, String> params) {
         List<URI> endpoints = config.getUidGeneratorServerUris();
         if (endpoints == null || endpoints.isEmpty()) {
             throw new ClientValidationException("At least one uid generator server URI is required");
@@ -38,13 +49,17 @@ public class Http2Requester {
         int startIndex = config.nextEndpointIndex(endpoints.size());
         ClientHttpRequestException lastError = null;
         for (int attempt = 0; attempt < attempts; attempt++) {
-            URI baseUri = endpoints.get((startIndex + attempt) % endpoints.size());
+            URI baseUri = selectEndpoint(endpoints, startIndex + attempt);
             URI uri = buildUri(baseUri, path, params);
             try {
                 HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri)
                     .timeout(config.getReadTimeout())
-                    .GET()
                     .header("Accept", "application/json");
+                if ("POST".equals(method)) {
+                    requestBuilder.POST(HttpRequest.BodyPublishers.noBody());
+                } else {
+                    requestBuilder.GET();
+                }
                 if (hasText(config.getToken())) {
                     requestBuilder.header("Authorization", "Bearer " + config.getToken());
                 }
@@ -53,16 +68,53 @@ public class Http2Requester {
                 if (response.statusCode() == 200) {
                     return response.body();
                 }
+                markUnhealthy(baseUri, config.getFailurePenalty());
                 lastError = new ClientHttpRequestException(
                     "HTTP Code:" + response.statusCode() + ", Message:" + response.body());
             } catch (IOException ex) {
+                markUnhealthy(baseUri, config.getFailurePenalty());
                 lastError = new ClientHttpRequestException("HTTP request failed: " + uri, ex);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new ClientHttpRequestException("HTTP request interrupted: " + uri, ex);
             }
+            backoff(config, attempt, attempts);
         }
         throw lastError == null ? new ClientHttpRequestException("HTTP request failed") : lastError;
+    }
+
+    private static URI selectEndpoint(List<URI> endpoints, int startIndex) {
+        long now = System.nanoTime();
+        for (int offset = 0; offset < endpoints.size(); offset++) {
+            URI endpoint = endpoints.get(Math.floorMod(startIndex + offset, endpoints.size()));
+            AtomicLong unhealthyUntil = UNHEALTHY_UNTIL_NANOS.get(endpoint);
+            if (unhealthyUntil == null || unhealthyUntil.get() <= now) {
+                return endpoint;
+            }
+        }
+        return endpoints.get(Math.floorMod(startIndex, endpoints.size()));
+    }
+
+    private static void markUnhealthy(URI endpoint, Duration penalty) {
+        Duration safePenalty = penalty == null ? Duration.ofSeconds(1) : penalty;
+        if (safePenalty.isZero() || safePenalty.isNegative()) {
+            return;
+        }
+        long until = System.nanoTime() + safePenalty.toNanos();
+        UNHEALTHY_UNTIL_NANOS.computeIfAbsent(endpoint, key -> new AtomicLong()).set(until);
+    }
+
+    private static void backoff(Config config, int attempt, int attempts) {
+        Duration backoff = config.getRetryBackoff();
+        if (attempt >= attempts - 1 || backoff == null || backoff.isZero() || backoff.isNegative()) {
+            return;
+        }
+        try {
+            Thread.sleep(backoff.toMillis());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new ClientHttpRequestException("HTTP retry interrupted", ex);
+        }
     }
 
     private static HttpClient client(Duration connectTimeout) {

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/UidClientBuilder.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/UidClientBuilder.java
@@ -37,6 +37,26 @@ public final class UidClientBuilder {
         return this;
     }
 
+    public UidClientBuilder setMachineId(long machineId) {
+        this.config.setMachineId(machineId);
+        return this;
+    }
+
+    public UidClientBuilder isContainer(boolean container) {
+        this.config.setContainer(container);
+        return this;
+    }
+
+    public UidClientBuilder setPodName(String podName) {
+        this.config.setPodName(podName);
+        return this;
+    }
+
+    public UidClientBuilder setMaxBackwardMillis(long maxBackwardMillis) {
+        this.config.setMaxBackwardMillis(maxBackwardMillis);
+        return this;
+    }
+
     public UidClientBuilder setConnectTimeout(Duration connectTimeout) {
         this.config.setConnectTimeout(connectTimeout);
         return this;
@@ -52,8 +72,23 @@ public final class UidClientBuilder {
         return this;
     }
 
+    public UidClientBuilder setRetryBackoff(Duration retryBackoff) {
+        this.config.setRetryBackoff(retryBackoff);
+        return this;
+    }
+
+    public UidClientBuilder setFailurePenalty(Duration failurePenalty) {
+        this.config.setFailurePenalty(failurePenalty);
+        return this;
+    }
+
     public UidClientBuilder setPrefetchThreads(int prefetchThreads) {
         this.config.setPrefetchThreads(prefetchThreads);
+        return this;
+    }
+
+    public UidClientBuilder setSegmentWaitTimeoutMillis(long segmentWaitTimeoutMillis) {
+        this.config.setSegmentWaitTimeoutMillis(segmentWaitTimeoutMillis);
         return this;
     }
 

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/UidClientImpl.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/UidClientImpl.java
@@ -11,11 +11,11 @@ import com.github.mxsm.rain.uid.core.common.SnowflakeUidParsedResult;
  */
 public class UidClientImpl implements UidClient {
 
-    private SegmentUidGeneratorClientImpl segmentService;
+    private final SegmentUidGeneratorClientImpl segmentService;
 
-    private SnowflakeUidGeneratorClientImpl snowflakeService;
+    private final SnowflakeUidGeneratorClientImpl snowflakeService;
 
-    private boolean segmentUidFromRemote;
+    private final boolean segmentUidFromRemote;
 
     public UidClientImpl(Config config) {
 

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/service/SegmentUidGeneratorClientImpl.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/service/SegmentUidGeneratorClientImpl.java
@@ -55,7 +55,7 @@ public class SegmentUidGeneratorClientImpl extends AbstractSegmentUidGenerator i
     @Override
     public SegmentPanel createSegmentPanel(String bizCode, int stepSize) {
         List<Segment> segments = getSegments(bizCode, stepSize);
-        return new SegmentPanel(bizCode, stepSize, threshold, segments, this);
+        return new SegmentPanel(bizCode, stepSize, threshold, segments, this, config.getSegmentWaitTimeoutMillis());
 
     }
 
@@ -106,7 +106,7 @@ public class SegmentUidGeneratorClientImpl extends AbstractSegmentUidGenerator i
     public long getUID(String bizCode) throws UidGenerateException {
         StringBuilder path = new StringBuilder(SEGMENT_UID_PATH).append(bizCode);
         try {
-            String content = Http2Requester.executeGET(config, path.toString());
+            String content = Http2Requester.executePOST(config, path.toString());
             Result<Long> result = OBJECT_MAPPER.readValue(content, new TypeReference<>() {
             });
             if (!result.isSuccess()) {

--- a/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/service/SnowflakeUidGeneratorClientImpl.java
+++ b/rain-uidgenerator-client/src/main/java/com/github/mxsm/rain/uid/client/service/SnowflakeUidGeneratorClientImpl.java
@@ -8,6 +8,7 @@ import com.github.mxsm.rain.uid.core.common.ErrorCode;
 import com.github.mxsm.rain.uid.core.common.Result;
 import com.github.mxsm.rain.uid.core.SnowflakeUidGenerator;
 import com.github.mxsm.rain.uid.core.exception.UidGenerateException;
+import com.github.mxsm.rain.uid.core.exception.UidUnavailableException;
 import com.github.mxsm.rain.uid.core.snowflake.AbstractSnowflakeUidGenerator;
 
 
@@ -27,15 +28,26 @@ public class SnowflakeUidGeneratorClientImpl extends AbstractSnowflakeUidGenerat
     private boolean snowflakeUidFromRemote;
 
     public SnowflakeUidGeneratorClientImpl(Config config) {
-        super(config.getEpoch(), config.isTimeBitsSecond(),config.getTimestampBits(), config.getMachineIdBits(), config.getSequenceBits());
+        super(config.getEpoch(), config.isTimeBitsSecond(), config.getTimestampBits(), config.getMachineIdBits(),
+            config.getSequenceBits(), config.getMaxBackwardMillis());
         this.config = config;
         this.snowflakeUidFromRemote = config.isSnowflakeUidFromRemote();
-        super.getBitsAllocator().setMachineId(getMachineId());
+        if (!snowflakeUidFromRemote) {
+            super.getBitsAllocator().setMachineId(getMachineId());
+        }
     }
 
     @Override
     public long getMachineId() {
-        return randomMachineId();
+        Long configuredMachineId = config.getMachineId();
+        if (configuredMachineId != null) {
+            return validateMachineId(configuredMachineId);
+        }
+        if (config.isContainer()) {
+            return validateMachineId(parsePodOrdinal(config.getPodName()));
+        }
+        throw new UidUnavailableException(ErrorCode.WORKER_ID_UNAVAILABLE,
+            "Local snowflake machineId must be configured, or container podName must contain a StatefulSet ordinal");
     }
 
     /**
@@ -51,7 +63,7 @@ public class SnowflakeUidGeneratorClientImpl extends AbstractSnowflakeUidGenerat
 
     public long getUidFromRemote() {
         try {
-            String content = Http2Requester.executeGET(config, SNOWFLAKE_UDI_PATH);
+            String content = Http2Requester.executePOST(config, SNOWFLAKE_UDI_PATH);
             Result<Long> result = OBJECT_MAPPER.readValue(content, new TypeReference<>() {
             });
             if (!result.isSuccess()) {
@@ -64,6 +76,32 @@ public class SnowflakeUidGeneratorClientImpl extends AbstractSnowflakeUidGenerat
                 throw uidGenerateException;
             }
             throw new UidGenerateException("Get Uid from remote [URL=" + SNOWFLAKE_UDI_PATH + "] error", e);
+        }
+    }
+
+    private long validateMachineId(long machineId) {
+        if (machineId < 0 || machineId > getBitsAllocator().getMaxMachineId()) {
+            throw new UidUnavailableException(ErrorCode.WORKER_ID_UNAVAILABLE,
+                "machineId " + machineId + " is outside 0-" + getBitsAllocator().getMaxMachineId());
+        }
+        return machineId;
+    }
+
+    private long parsePodOrdinal(String podName) {
+        if (podName == null || podName.isBlank()) {
+            throw new UidUnavailableException(ErrorCode.WORKER_ID_UNAVAILABLE,
+                "podName must be configured for local snowflake container mode");
+        }
+        int dashIndex = podName.lastIndexOf('-');
+        if (dashIndex < 0 || dashIndex == podName.length() - 1) {
+            throw new UidUnavailableException(ErrorCode.WORKER_ID_UNAVAILABLE,
+                "Unable to parse StatefulSet ordinal from podName: " + podName);
+        }
+        try {
+            return Long.parseLong(podName.substring(dashIndex + 1));
+        } catch (NumberFormatException ex) {
+            throw new UidUnavailableException(ErrorCode.WORKER_ID_UNAVAILABLE,
+                "Unable to parse StatefulSet ordinal from podName: " + podName, ex);
         }
     }
 }

--- a/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/Http2RequesterTest.java
+++ b/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/Http2RequesterTest.java
@@ -56,6 +56,14 @@ class Http2RequesterTest {
         assertEquals("authorized", Http2Requester.executeGET(config, "/uid"));
     }
 
+    @Test
+    void sendsPostRequests() throws Exception {
+        TestServer server = startMethodServer("POST");
+        Config config = config(server.uri());
+
+        assertEquals("POST", Http2Requester.executePOST(config, "/uid"));
+    }
+
     private Config config(String... uris) {
         Config config = new Config();
         config.setUidGeneratorServerUris(List.of(uris));
@@ -87,6 +95,25 @@ class Http2RequesterTest {
                 return;
             }
             write(exchange, 401, "unauthorized");
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "test-http-server");
+            thread.setDaemon(true);
+            return thread;
+        }));
+        server.start();
+        servers.add(server);
+        return new TestServer(server);
+    }
+
+    private TestServer startMethodServer(String expectedMethod) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/uid", exchange -> {
+            if (expectedMethod.equals(exchange.getRequestMethod())) {
+                write(exchange, 200, exchange.getRequestMethod());
+                return;
+            }
+            write(exchange, 405, exchange.getRequestMethod());
         });
         server.setExecutor(Executors.newSingleThreadExecutor(runnable -> {
             Thread thread = new Thread(runnable, "test-http-server");

--- a/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/UidClientTest.java
+++ b/rain-uidgenerator-client/src/test/java/com/github/mxsm/rain/uid/client/UidClientTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.mxsm.rain.uid.client.service.SegmentUidGeneratorClientImpl;
 import com.github.mxsm.rain.uid.core.common.SnowflakeUidParsedResult;
+import com.github.mxsm.rain.uid.core.exception.UidUnavailableException;
 import com.github.mxsm.rain.uid.core.segment.Segment;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,10 +77,35 @@ class UidClientTest {
         }
     }
 
+    @Test
+    void localSnowflakeRequiresDeterministicMachineId() {
+        assertThrows(UidUnavailableException.class, () -> UidClient.builder()
+            .isSnowflakeUidFromRemote(false)
+            .build());
+    }
+
+    @Test
+    void localSnowflakeCanUseStatefulSetPodOrdinal() {
+        UidClient client = UidClient.builder()
+            .isSnowflakeUidFromRemote(false)
+            .isSegmentUidFromRemote(false)
+            .isContainer(true)
+            .setPodName("rain-uidgenerator-3")
+            .build();
+        try {
+            SnowflakeUidParsedResult result = client.parseSnowflakeUid(client.getSnowflakeUid());
+
+            assertEquals(3, result.getMachineId());
+        } finally {
+            client.shutdown();
+        }
+    }
+
     private UidClient localClient() {
         return UidClient.builder()
             .isSegmentUidFromRemote(false)
             .isSnowflakeUidFromRemote(false)
+            .setMachineId(1)
             .build();
     }
 

--- a/rain-uidgenerator-core/src/main/java/com/github/mxsm/rain/uid/core/segment/SegmentPanel.java
+++ b/rain-uidgenerator-core/src/main/java/com/github/mxsm/rain/uid/core/segment/SegmentPanel.java
@@ -1,6 +1,5 @@
 package com.github.mxsm.rain.uid.core.segment;
 
-import com.github.mxsm.rain.uid.core.exception.SegmentOutOfBoundaryException;
 import com.github.mxsm.rain.uid.core.common.ErrorCode;
 import com.github.mxsm.rain.uid.core.exception.UidUnavailableException;
 import java.util.List;
@@ -20,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SegmentPanel {
 
-    private Logger LOGGER = LoggerFactory.getLogger(SegmentPanel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPanel.class);
 
     private BlockingQueue<Segment> segmentQueue;
 
@@ -38,10 +37,17 @@ public class SegmentPanel {
 
     private int capacity;
 
+    private long waitTimeoutMillis;
+
     private final AtomicBoolean refillInProgress = new AtomicBoolean(false);
 
     public SegmentPanel(String bizCode, int capacity, int threshold, List<Segment> segments,
         SegmentConsumerListener listener) {
+        this(bizCode, capacity, threshold, segments, listener, 3000L);
+    }
+
+    public SegmentPanel(String bizCode, int capacity, int threshold, List<Segment> segments,
+        SegmentConsumerListener listener, long waitTimeoutMillis) {
 
         this.bizCode = bizCode;
         this.capacity = capacity <= 0 ? 16 : capacity;
@@ -50,7 +56,8 @@ public class SegmentPanel {
             this.segmentQueue.addAll(segments);
         }
         this.listener = listener;
-        this.threshold = threshold;
+        this.threshold = Math.max(0, Math.min(100, threshold));
+        this.waitTimeoutMillis = waitTimeoutMillis <= 0 ? 3000L : waitTimeoutMillis;
         this.currentSegment = this.segmentQueue.poll();
     }
 
@@ -75,7 +82,7 @@ public class SegmentPanel {
                 return;
             }
             maybeRequestRefill();
-            this.currentSegment = segmentQueue.poll(3, TimeUnit.SECONDS);
+            this.currentSegment = segmentQueue.poll(waitTimeoutMillis, TimeUnit.MILLISECONDS);
             if (this.currentSegment == null) {
                 throw new UidUnavailableException(ErrorCode.UID_UNAVAILABLE,
                     "No segment is available for bizCode " + bizCode);
@@ -108,17 +115,25 @@ public class SegmentPanel {
         }
     }
 
-    public void addSegment(Segment segment) {
-        this.segmentQueue.offer(segment);
+    public boolean addSegment(Segment segment) {
+        boolean added = this.segmentQueue.offer(segment);
+        if (!added) {
+            LOGGER.warn("Segment queue is full, discard allocated segment. bizCode={}", bizCode);
+        }
+        return added;
     }
 
-    public void addSegment(List<Segment> segments) {
+    public int addSegment(List<Segment> segments) {
         if (segments == null) {
-            return;
+            return 0;
         }
+        int added = 0;
         for (Segment segment : segments) {
-            this.addSegment(segment);
+            if (this.addSegment(segment)) {
+                added++;
+            }
         }
+        return added;
     }
 
     public String getBizCode() {

--- a/rain-uidgenerator-core/src/main/java/com/github/mxsm/rain/uid/core/snowflake/AbstractSnowflakeUidGenerator.java
+++ b/rain-uidgenerator-core/src/main/java/com/github/mxsm/rain/uid/core/snowflake/AbstractSnowflakeUidGenerator.java
@@ -116,7 +116,8 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
             if (currentTimestamp < lastTimestamp) {
                 long offset = lastTimestamp - currentTimestamp;
                 if (offset <= maxBackwardMillis) {
-                    currentTimestamp = tillNextMillis(lastTimestamp);
+                    onClockMovedBackwards(offset);
+                    currentTimestamp = waitUntilMillis(lastTimestamp, maxBackwardMillis);
                 } else {
                     onClockMovedBackwards(offset);
                     throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
@@ -146,7 +147,8 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
             if (currentTimestamp < lastTimestamp) {
                 long offset = lastTimestamp - currentTimestamp;
                 if (offset <= maxBackwardMillis) {
-                    currentTimestamp = tillNextMillis(lastTimestamp);
+                    onClockMovedBackwards(offset);
+                    currentTimestamp = waitUntilMillis(lastTimestamp, maxBackwardMillis);
                 } else {
                     onClockMovedBackwards(offset);
                     throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
@@ -180,7 +182,8 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
             if (currentTimestamp < lastCurrent) {
                 long offset = lastCurrent - currentTimestamp;
                 if (offset <= maxBackwardMillis) {
-                    currentTimestamp = tillNextMillis(lastCurrent);
+                    onClockMovedBackwards(offset);
+                    currentTimestamp = waitUntilMillis(lastCurrent, maxBackwardMillis);
                 } else {
                     onClockMovedBackwards(offset);
                     throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
@@ -212,6 +215,27 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
         return currentTimestamp;
     }
 
+    private long waitUntilMillis(long targetTimestamp, long maxWaitMillis) {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(Math.max(1, maxWaitMillis));
+        long currentTimestamp = System.currentTimeMillis();
+        while (currentTimestamp <= targetTimestamp) {
+            if (System.nanoTime() > deadline) {
+                onClockMovedBackwards(targetTimestamp - currentTimestamp);
+                throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
+                    "Time rollback wait exceeds " + maxWaitMillis + "ms");
+            }
+            try {
+                Thread.sleep(Math.min(5L, Math.max(1L, targetTimestamp - currentTimestamp)));
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
+                    "Interrupted while waiting for clock recovery", ex);
+            }
+            currentTimestamp = System.currentTimeMillis();
+        }
+        return currentTimestamp;
+    }
+
     private long nextIdExt() {
 
         synchronized (lockExt) {
@@ -222,7 +246,7 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
                 long refusedSeconds = lastTimestamp - currentSecond;
                 onClockMovedBackwards(TimeUnit.SECONDS.toMillis(refusedSeconds));
                 if (refusedSeconds <= maxBackwardSeconds) {
-                    currentSecond = getNextSecond(lastTimestamp);
+                    currentSecond = waitUntilSecond(lastTimestamp, maxBackwardSeconds);
                 } else {
                     throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
                         "Time rollback exceeds " + maxBackwardSeconds + "s");
@@ -323,9 +347,37 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
     private long getNextSecond(long lastTimestamp) {
         long timestamp = getCurrentSecond();
         while (timestamp <= lastTimestamp) {
+            try {
+                Thread.sleep(1L);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
+                    "Interrupted while waiting for next second", ex);
+            }
             timestamp = getCurrentSecond();
         }
         return timestamp;
+    }
+
+    private long waitUntilSecond(long targetSecond, long maxWaitSeconds) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(Math.max(1, maxWaitSeconds));
+        long currentSecond = getCurrentSecond();
+        while (currentSecond <= targetSecond) {
+            if (System.nanoTime() > deadline) {
+                onClockMovedBackwards(TimeUnit.SECONDS.toMillis(targetSecond - currentSecond));
+                throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
+                    "Time rollback wait exceeds " + maxWaitSeconds + "s");
+            }
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new UidUnavailableException(ErrorCode.CLOCK_MOVED_BACKWARDS,
+                    "Interrupted while waiting for clock recovery", ex);
+            }
+            currentSecond = getCurrentSecond();
+        }
+        return currentSecond;
     }
 
     /**
@@ -338,12 +390,6 @@ public abstract class AbstractSnowflakeUidGenerator implements SnowflakeUidGener
                 "Timestamp bits is exhausted. Refusing UID generate. Now: " + currentSecond + ", epoch: " + epoch);
         }
         return currentSecond;
-    }
-
-    protected long randomMachineId() {
-        long machineId = (long) (Math.random() * getBitsAllocator().getMaxMachineId());
-        LOGGER.info("Random machine id is {}", machineId);
-        return machineId;
     }
 
     protected void onClockMovedBackwards(long rollbackMillis) {

--- a/rain-uidgenerator-core/src/test/java/com/github/mxsm/rain/uid/core/segment/SegmentPanelTest.java
+++ b/rain-uidgenerator-core/src/test/java/com/github/mxsm/rain/uid/core/segment/SegmentPanelTest.java
@@ -1,8 +1,11 @@
 package com.github.mxsm.rain.uid.core.segment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.mxsm.rain.uid.core.exception.UidUnavailableException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -53,6 +56,21 @@ class SegmentPanelTest {
 
         assertEquals(800, ids.size());
         assertEquals(800, new HashSet<>(ids).size());
+    }
+
+    @Test
+    void throwsUnavailableWhenNoSegmentArrivesBeforeTimeout() {
+        SegmentPanel panel = new SegmentPanel("biz", 1, 50, List.of(), null, 10);
+
+        assertThrows(UidUnavailableException.class, panel::getUid);
+    }
+
+    @Test
+    void reportsRejectedSegmentsWhenQueueIsFull() {
+        SegmentPanel panel = new SegmentPanel("biz", 1, 50, List.of(new Segment(1, 100)), null);
+
+        assertTrue(panel.addSegment(new Segment(100, 100)));
+        assertFalse(panel.addSegment(new Segment(200, 100)));
     }
 
     private static List<Segment> segments(AtomicLong nextStart, int segmentNum) {

--- a/rain-uidgenerator-jmh/src/main/java/com/github/mxsm/rain/jmh/SnowflakeClientLocalBenchmark.java
+++ b/rain-uidgenerator-jmh/src/main/java/com/github/mxsm/rain/jmh/SnowflakeClientLocalBenchmark.java
@@ -40,7 +40,10 @@ public class SnowflakeClientLocalBenchmark {
 
     @Setup
     public void init() {
-        uidClient = UidClient.builder().isSnowflakeUidFromRemote(false).build();
+        uidClient = UidClient.builder()
+            .isSnowflakeUidFromRemote(false)
+            .setMachineId(1)
+            .build();
     }
 
     @Benchmark

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/config/SegmentUidGeneratorConfig.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/config/SegmentUidGeneratorConfig.java
@@ -18,6 +18,8 @@ public class SegmentUidGeneratorConfig {
 
     private int prefetchThreads = 4;
 
+    private long waitTimeoutMillis = 3000L;
+
     public int getCacheSize() {
         return cacheSize;
     }
@@ -40,5 +42,13 @@ public class SegmentUidGeneratorConfig {
 
     public void setPrefetchThreads(int prefetchThreads) {
         this.prefetchThreads = prefetchThreads;
+    }
+
+    public long getWaitTimeoutMillis() {
+        return waitTimeoutMillis;
+    }
+
+    public void setWaitTimeoutMillis(long waitTimeoutMillis) {
+        this.waitTimeoutMillis = waitTimeoutMillis;
     }
 }

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/config/UidSecurityProperties.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/config/UidSecurityProperties.java
@@ -13,6 +13,8 @@ public class UidSecurityProperties {
 
     private List<String> tokens = new ArrayList<>();
 
+    private List<String> adminTokens = new ArrayList<>();
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -26,6 +28,14 @@ public class UidSecurityProperties {
     }
 
     public void setTokens(List<String> tokens) {
-        this.tokens = tokens;
+        this.tokens = tokens == null ? new ArrayList<>() : tokens;
+    }
+
+    public List<String> getAdminTokens() {
+        return adminTokens;
+    }
+
+    public void setAdminTokens(List<String> adminTokens) {
+        this.adminTokens = adminTokens == null ? new ArrayList<>() : adminTokens;
     }
 }

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SegmentUidGeneratorController.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SegmentUidGeneratorController.java
@@ -6,12 +6,11 @@ import com.github.mxsm.rain.uid.core.segment.Segment;
 import com.github.mxsm.rain.uid.dto.BizCodeRegisterReqDto;
 import com.github.mxsm.rain.uid.observability.UidMetrics;
 import com.github.mxsm.rain.uid.service.AllocationService;
-import java.util.List;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,56 +21,50 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * @author mxsm
- * @date 2022/4/17 16:07
- * @Since 1.0.0
+ * Segment UID API.
  */
 @RestController
 @RequestMapping("/api/v1/segment")
 @Validated
 public class SegmentUidGeneratorController {
 
-    @Autowired
-    private AllocationService allocationService;
+    private final AllocationService allocationService;
 
-    @Autowired
-    private SegmentUidGenerator segmentUidGenerator;
+    private final SegmentUidGenerator segmentUidGenerator;
 
-    @Autowired
-    private UidMetrics uidMetrics;
+    private final UidMetrics uidMetrics;
 
-    @PostMapping("/rg")
-    public Result<Boolean> registerBizCode(@RequestBody @Valid BizCodeRegisterReqDto params){
-        String bizCode = params.getBizCode();
-        Integer step = params.getStep();
-        return Result.buildSuccess(allocationService.registerBizCode(bizCode,step));
+    public SegmentUidGeneratorController(AllocationService allocationService, SegmentUidGenerator segmentUidGenerator,
+        UidMetrics uidMetrics) {
+        this.allocationService = allocationService;
+        this.segmentUidGenerator = segmentUidGenerator;
+        this.uidMetrics = uidMetrics;
     }
 
-    /**
-     * get uid by bizcode
-     *
-     * @param bizCode
-     * @return
-     */
-    @GetMapping("/uid/{bizCode}")
-    public Result<Long> getUid(@PathVariable("bizCode") @NotBlank String bizCode) {
+    @PostMapping("/rg")
+    public Result<Boolean> registerBizCode(@RequestBody @Valid BizCodeRegisterReqDto params) {
+        return Result.buildSuccess(allocationService.registerBizCode(params.getBizCode(), params.getStep()));
+    }
+
+    @PostMapping("/uid/{bizCode}")
+    public Result<Long> createUid(@PathVariable("bizCode") @NotBlank String bizCode) {
         long uid = segmentUidGenerator.getUID(bizCode);
         uidMetrics.recordSegmentGenerated();
         return Result.buildSuccess(uid);
     }
 
     /**
-     * get bizcode step
-     *
-     * @param bizCode
-     * @param segmentNum number of step
-     * @return
+     * @deprecated UID generation has side effects. Use POST /api/v1/segment/uid/{bizCode}.
      */
+    @Deprecated(since = "1.0.1", forRemoval = false)
+    @GetMapping("/uid/{bizCode}")
+    public Result<Long> getUid(@PathVariable("bizCode") @NotBlank String bizCode) {
+        return createUid(bizCode);
+    }
+
     @GetMapping("/list/{bizCode}")
     public Result<List<Segment>> getStep(@PathVariable("bizCode") @NotBlank String bizCode,
         @RequestParam("segmentNum") @Min(1) @Max(10000) Integer segmentNum) {
-        List<Segment> segments = allocationService.getSegments(bizCode, segmentNum);
-        return Result.buildSuccess(segments);
+        return Result.buildSuccess(allocationService.getSegments(bizCode, segmentNum));
     }
-
 }

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SnowflakeUidGeneratorController.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/controller/SnowflakeUidGeneratorController.java
@@ -1,41 +1,49 @@
 package com.github.mxsm.rain.uid.controller;
 
-
 import com.github.mxsm.rain.uid.core.SnowflakeUidGenerator;
 import com.github.mxsm.rain.uid.core.common.Result;
 import com.github.mxsm.rain.uid.core.common.SnowflakeUidParsedResult;
 import com.github.mxsm.rain.uid.observability.UidMetrics;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * @author mxsm
- * @date 2022/5/1 17:28
- * @Since 1.0.0
+ * Snowflake UID API.
  */
 @RestController
 @RequestMapping("/api/v1/snowflake")
 public class SnowflakeUidGeneratorController {
 
-    @Autowired
-    private SnowflakeUidGenerator snowflakeUidGenerator;
+    private final SnowflakeUidGenerator snowflakeUidGenerator;
 
-    @Autowired
-    private UidMetrics uidMetrics;
+    private final UidMetrics uidMetrics;
 
-    @GetMapping("/uid")
-    public Result<Long> getUid() {
+    public SnowflakeUidGeneratorController(SnowflakeUidGenerator snowflakeUidGenerator, UidMetrics uidMetrics) {
+        this.snowflakeUidGenerator = snowflakeUidGenerator;
+        this.uidMetrics = uidMetrics;
+    }
+
+    @PostMapping("/uid")
+    public Result<Long> createUid() {
         long uid = snowflakeUidGenerator.getUID();
         uidMetrics.recordSnowflakeGenerated();
         return Result.buildSuccess(uid);
     }
 
-    @GetMapping("/parse/{uid}")
-    public Result<SnowflakeUidParsedResult> getUid(@PathVariable("uid") Long uid) {
-        return Result.buildSuccess(snowflakeUidGenerator.parseUID(uid));
+    /**
+     * @deprecated UID generation has side effects. Use POST /api/v1/snowflake/uid.
+     */
+    @Deprecated(since = "1.0.1", forRemoval = false)
+    @GetMapping("/uid")
+    public Result<Long> getUid() {
+        return createUid();
     }
 
+    @GetMapping("/parse/{uid}")
+    public Result<SnowflakeUidParsedResult> parseUid(@PathVariable("uid") Long uid) {
+        return Result.buildSuccess(snowflakeUidGenerator.parseUID(uid));
+    }
 }

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/generate/SegmentConsumerListenerImpl.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/generate/SegmentConsumerListenerImpl.java
@@ -5,6 +5,7 @@ import com.github.mxsm.rain.uid.config.SegmentUidGeneratorConfig;
 import com.github.mxsm.rain.uid.core.segment.Segment;
 import com.github.mxsm.rain.uid.core.segment.SegmentConsumerListener;
 import com.github.mxsm.rain.uid.core.segment.SegmentPanel;
+import com.github.mxsm.rain.uid.observability.UidMetrics;
 import com.github.mxsm.rain.uid.service.AllocationService;
 import jakarta.annotation.PreDestroy;
 import java.util.List;
@@ -24,10 +25,14 @@ public class SegmentConsumerListenerImpl implements SegmentConsumerListener {
 
     private final AllocationService allocationService;
 
+    private final UidMetrics uidMetrics;
+
     private final ExecutorService executorService;
 
-    public SegmentConsumerListenerImpl(AllocationService allocationService, SegmentUidGeneratorConfig config) {
+    public SegmentConsumerListenerImpl(AllocationService allocationService, SegmentUidGeneratorConfig config,
+        UidMetrics uidMetrics) {
         this.allocationService = allocationService;
+        this.uidMetrics = uidMetrics;
         int threads = Math.max(1, config.getPrefetchThreads());
         this.executorService = Executors.newFixedThreadPool(threads, new PrefetchThreadFactory());
     }
@@ -38,7 +43,8 @@ public class SegmentConsumerListenerImpl implements SegmentConsumerListener {
             try {
                 String bizCode = segmentPanel.getBizCode();
                 List<Segment> segments = allocationService.getSegments(bizCode, segmentNum);
-                segmentPanel.addSegment(segments);
+                int added = segmentPanel.addSegment(segments);
+                uidMetrics.recordSegmentDiscarded(segments.size() - added);
                 segmentPanel.resetCounter();
             } finally {
                 segmentPanel.refillFinished();

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/generate/SegmentUidGeneratorServerImpl.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/generate/SegmentUidGeneratorServerImpl.java
@@ -8,7 +8,6 @@ import com.github.mxsm.rain.uid.core.segment.SegmentPanel;
 import com.github.mxsm.rain.uid.service.AllocationService;
 
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -19,22 +18,24 @@ import org.springframework.stereotype.Service;
 @Service("uidGenerator")
 public class SegmentUidGeneratorServerImpl extends AbstractSegmentUidGenerator {
 
-    @Autowired
-    private AllocationService allocationService;
+    private final AllocationService allocationService;
 
-    private SegmentUidGeneratorConfig config;
+    private final SegmentUidGeneratorConfig config;
 
-    @Autowired
-    private SegmentConsumerListener listener;
+    private final SegmentConsumerListener listener;
 
-    public SegmentUidGeneratorServerImpl(SegmentUidGeneratorConfig config) {
+    public SegmentUidGeneratorServerImpl(SegmentUidGeneratorConfig config, AllocationService allocationService,
+        SegmentConsumerListener listener) {
         super(config.getCacheSize());
         this.config = config;
+        this.allocationService = allocationService;
+        this.listener = listener;
     }
 
     @Override
     public SegmentPanel createSegmentPanel(String bizCode, int segmentNum) {
-        return new SegmentPanel(bizCode, segmentNum, config.getThreshold(), getSegments(bizCode, segmentNum), listener);
+        return new SegmentPanel(bizCode, segmentNum, config.getThreshold(), getSegments(bizCode, segmentNum), listener,
+            config.getWaitTimeoutMillis());
     }
 
     @Override

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/observability/UidMetrics.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/observability/UidMetrics.java
@@ -13,6 +13,7 @@ public class UidMetrics {
     private final Counter segmentGenerated;
     private final Counter snowflakeGenerated;
     private final Counter segmentAllocationFailure;
+    private final Counter segmentDiscarded;
     private final Counter clockRollback;
     private final Timer segmentAllocationTimer;
     private final AtomicLong workerId = new AtomicLong(-1);
@@ -21,6 +22,7 @@ public class UidMetrics {
         this.segmentGenerated = Counter.builder("rain_uid_segment_generated_total").register(registry);
         this.snowflakeGenerated = Counter.builder("rain_uid_snowflake_generated_total").register(registry);
         this.segmentAllocationFailure = Counter.builder("rain_uid_segment_allocation_failed_total").register(registry);
+        this.segmentDiscarded = Counter.builder("rain_uid_segment_discarded_total").register(registry);
         this.clockRollback = Counter.builder("rain_uid_snowflake_clock_rollback_total").register(registry);
         this.segmentAllocationTimer = Timer.builder("rain_uid_segment_allocation_duration").register(registry);
         registry.gauge("rain_uid_snowflake_worker_id", workerId);
@@ -40,6 +42,12 @@ public class UidMetrics {
 
     public void recordSegmentAllocationFailure() {
         segmentAllocationFailure.increment();
+    }
+
+    public void recordSegmentDiscarded(long count) {
+        if (count > 0) {
+            segmentDiscarded.increment(count);
+        }
     }
 
     public void recordClockRollback() {

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/security/NoStoreCacheControlFilter.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/security/NoStoreCacheControlFilter.java
@@ -1,0 +1,40 @@
+package com.github.mxsm.rain.uid.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class NoStoreCacheControlFilter extends OncePerRequestFilter {
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = pathWithinApplication(request);
+        return !path.startsWith("/api/v1/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, max-age=0");
+        response.setHeader(HttpHeaders.PRAGMA, "no-cache");
+        filterChain.doFilter(request, response);
+    }
+
+    private String pathWithinApplication(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isBlank() && uri.startsWith(contextPath)) {
+            return uri.substring(contextPath.length());
+        }
+        return uri;
+    }
+}

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/security/TokenAuthenticationFilter.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/security/TokenAuthenticationFilter.java
@@ -23,6 +23,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String API_KEY_HEADER = "X-API-Key";
 
+    private static final String ADMIN_SEGMENT_REGISTER_PATH = "/api/v1/segment/rg";
+
     private final UidSecurityProperties properties;
 
     private final ObjectMapper objectMapper;
@@ -34,7 +36,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
+        String path = pathWithinApplication(request);
         return !properties.isEnabled()
             || path.startsWith("/actuator/health")
             || path.startsWith("/actuator/info");
@@ -44,8 +46,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
         Set<String> allowedTokens = new HashSet<>(properties.getTokens());
+        Set<String> adminTokens = new HashSet<>(properties.getAdminTokens());
         String token = resolveToken(request);
-        if (allowedTokens.isEmpty() || !StringUtils.hasText(token) || !allowedTokens.contains(token)) {
+        if (!StringUtils.hasText(token) || !isAuthorized(request, token, allowedTokens, adminTokens)) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             objectMapper.writeValue(response.getOutputStream(),
@@ -53,6 +56,27 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isAuthorized(HttpServletRequest request, String token, Set<String> allowedTokens,
+        Set<String> adminTokens) {
+        if (isAdminEndpoint(request)) {
+            return adminTokens.contains(token);
+        }
+        return allowedTokens.contains(token) || adminTokens.contains(token);
+    }
+
+    private boolean isAdminEndpoint(HttpServletRequest request) {
+        return ADMIN_SEGMENT_REGISTER_PATH.equals(pathWithinApplication(request));
+    }
+
+    private String pathWithinApplication(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && uri.startsWith(contextPath)) {
+            return uri.substring(contextPath.length());
+        }
+        return uri;
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/service/AllocationServiceImpl.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/service/AllocationServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +24,14 @@ public class AllocationServiceImpl implements AllocationService{
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllocationServiceImpl.class);
 
-    @Autowired
-    private AllocationDao allocationDao;
+    private final AllocationDao allocationDao;
 
-    @Autowired
-    private UidMetrics uidMetrics;
+    private final UidMetrics uidMetrics;
+
+    public AllocationServiceImpl(AllocationDao allocationDao, UidMetrics uidMetrics) {
+        this.allocationDao = allocationDao;
+        this.uidMetrics = uidMetrics;
+    }
 
     @Override
     @Transactional(rollbackFor = Exception.class)
@@ -42,7 +44,19 @@ public class AllocationServiceImpl implements AllocationService{
             throw new UidGenerateException(ErrorCode.BIZ_CODE_NOT_FOUND, "bizCode not registered: " + bizCode);
         }
         Integer stepLength = allocation.getStep();
-        long totalLength = Math.multiplyExact(stepLength.longValue(), segmentNum);
+        if (stepLength == null || stepLength <= 0) {
+            uidMetrics.recordSegmentAllocationFailure();
+            throw new UidGenerateException(ErrorCode.SEGMENT_ALLOCATE_FAILED,
+                "Invalid step for bizCode " + bizCode);
+        }
+        long totalLength;
+        try {
+            totalLength = Math.multiplyExact(stepLength.longValue(), segmentNum);
+        } catch (ArithmeticException ex) {
+            uidMetrics.recordSegmentAllocationFailure();
+            throw new UidGenerateException(ErrorCode.SEGMENT_ALLOCATE_FAILED,
+                "Segment allocation overflows for bizCode " + bizCode, ex);
+        }
         int updated = allocationDao.updateAllocation(segmentNum, bizCode);
         if (updated != 1) {
             uidMetrics.recordSegmentAllocationFailure();

--- a/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/service/DefaultSnowflakeServerUidGeneratorImpl.java
+++ b/rain-uidgenerator-server/src/main/java/com/github/mxsm/rain/uid/service/DefaultSnowflakeServerUidGeneratorImpl.java
@@ -28,9 +28,9 @@ public class DefaultSnowflakeServerUidGeneratorImpl extends AbstractSnowflakeUid
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSnowflakeServerUidGeneratorImpl.class);
 
-    private static String EPOCH_DEFAULT = "2022-05-01";
+    private static final String EPOCH_DEFAULT = "2022-05-01";
 
-    private SnowflakeNodeDao snowflakeNodeDao;
+    private final SnowflakeNodeDao snowflakeNodeDao;
 
     private final SnowflakeUidGeneratorConfig config;
 
@@ -42,7 +42,7 @@ public class DefaultSnowflakeServerUidGeneratorImpl extends AbstractSnowflakeUid
     @Value("${server.address:}")
     private String hostName;
 
-    private DeployEnvType deployEnvType;
+    private final DeployEnvType deployEnvType;
 
     public DefaultSnowflakeServerUidGeneratorImpl(SnowflakeUidGeneratorConfig config,
         SnowflakeNodeDao snowflakeNodeDao, UidMetrics uidMetrics) {

--- a/rain-uidgenerator-server/src/main/resources/application-prod.yml
+++ b/rain-uidgenerator-server/src/main/resources/application-prod.yml
@@ -12,6 +12,7 @@ mxsm:
     security:
       enabled: ${RAIN_UID_SECURITY_ENABLED:true}
       tokens: ${RAIN_UID_TOKENS}
+      admin-tokens: ${RAIN_UID_ADMIN_TOKENS}
     snowflake:
       container: ${RAIN_UID_SNOWFLAKE_CONTAINER:true}
       pod-name: ${HOSTNAME}

--- a/rain-uidgenerator-server/src/main/resources/application.yml
+++ b/rain-uidgenerator-server/src/main/resources/application.yml
@@ -47,10 +47,12 @@ mxsm:
     security:
       enabled: ${RAIN_UID_SECURITY_ENABLED:false}
       tokens: ${RAIN_UID_TOKENS:}
+      admin-tokens: ${RAIN_UID_ADMIN_TOKENS:}
     segment:
       threshold: ${RAIN_UID_SEGMENT_THRESHOLD:40}
       cache-size: ${RAIN_UID_SEGMENT_CACHE_SIZE:16}
       prefetch-threads: ${RAIN_UID_SEGMENT_PREFETCH_THREADS:4}
+      wait-timeout-millis: ${RAIN_UID_SEGMENT_WAIT_TIMEOUT_MS:3000}
     snowflake:
       timestamp-bits: ${RAIN_UID_SNOWFLAKE_TIMESTAMP_BITS:41}
       machine-id-bits: ${RAIN_UID_SNOWFLAKE_MACHINE_ID_BITS:10}

--- a/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/controller/UidControllerResponseTest.java
+++ b/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/controller/UidControllerResponseTest.java
@@ -1,6 +1,7 @@
 package com.github.mxsm.rain.uid.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,7 +15,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -25,21 +25,17 @@ class UidControllerResponseTest {
     @BeforeEach
     void setUp() {
         UidMetrics metrics = new UidMetrics(new SimpleMeterRegistry());
-        SegmentUidGeneratorController segmentController = new SegmentUidGeneratorController();
-        ReflectionTestUtils.setField(segmentController, "allocationService", allocationService());
-        ReflectionTestUtils.setField(segmentController, "segmentUidGenerator", segmentUidGenerator());
-        ReflectionTestUtils.setField(segmentController, "uidMetrics", metrics);
-
-        SnowflakeUidGeneratorController snowflakeController = new SnowflakeUidGeneratorController();
-        ReflectionTestUtils.setField(snowflakeController, "snowflakeUidGenerator", snowflakeUidGenerator());
-        ReflectionTestUtils.setField(snowflakeController, "uidMetrics", metrics);
+        SegmentUidGeneratorController segmentController = new SegmentUidGeneratorController(allocationService(),
+            segmentUidGenerator(), metrics);
+        SnowflakeUidGeneratorController snowflakeController = new SnowflakeUidGeneratorController(
+            snowflakeUidGenerator(), metrics);
 
         mockMvc = MockMvcBuilders.standaloneSetup(segmentController, snowflakeController).build();
     }
 
     @Test
     void segmentUidReturnsResultEnvelope() throws Exception {
-        mockMvc.perform(get("/api/v1/segment/uid/biz"))
+        mockMvc.perform(post("/api/v1/segment/uid/biz"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("SUCCESS"))
             .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -48,10 +44,17 @@ class UidControllerResponseTest {
 
     @Test
     void snowflakeUidReturnsResultEnvelope() throws Exception {
-        mockMvc.perform(get("/api/v1/snowflake/uid"))
+        mockMvc.perform(post("/api/v1/snowflake/uid"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("SUCCESS"))
             .andExpect(jsonPath("$.code").value("SUCCESS"))
+            .andExpect(jsonPath("$.data").value(200));
+    }
+
+    @Test
+    void deprecatedGetUidStillWorks() throws Exception {
+        mockMvc.perform(get("/api/v1/snowflake/uid"))
+            .andExpect(status().isOk())
             .andExpect(jsonPath("$.data").value(200));
     }
 

--- a/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/security/NoStoreCacheControlFilterTest.java
+++ b/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/security/NoStoreCacheControlFilterTest.java
@@ -1,0 +1,24 @@
+package com.github.mxsm.rain.uid.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class NoStoreCacheControlFilterTest {
+
+    @Test
+    void addsNoStoreHeadersForApiRequests() throws Exception {
+        NoStoreCacheControlFilter filter = new NoStoreCacheControlFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/snowflake/uid");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("no-store, no-cache, max-age=0", response.getHeader(HttpHeaders.CACHE_CONTROL));
+        assertEquals("no-cache", response.getHeader(HttpHeaders.PRAGMA));
+    }
+}

--- a/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/security/TokenAuthenticationFilterTest.java
+++ b/rain-uidgenerator-server/src/test/java/com/github/mxsm/rain/uid/security/TokenAuthenticationFilterTest.java
@@ -53,4 +53,51 @@ class TokenAuthenticationFilterTest {
 
         assertEquals(200, response.getStatus());
     }
+
+    @Test
+    void rejectsGenerateTokenForAdminEndpoint() throws Exception {
+        UidSecurityProperties properties = new UidSecurityProperties();
+        properties.setEnabled(true);
+        properties.setTokens(List.of("generate"));
+        properties.setAdminTokens(List.of("admin"));
+        TokenAuthenticationFilter filter = new TokenAuthenticationFilter(properties, new ObjectMapper());
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/segment/rg");
+        request.addHeader("Authorization", "Bearer generate");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    void acceptsAdminTokenForAdminEndpoint() throws Exception {
+        UidSecurityProperties properties = new UidSecurityProperties();
+        properties.setEnabled(true);
+        properties.setTokens(List.of("generate"));
+        properties.setAdminTokens(List.of("admin"));
+        TokenAuthenticationFilter filter = new TokenAuthenticationFilter(properties, new ObjectMapper());
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/segment/rg");
+        request.addHeader("Authorization", "Bearer admin");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void acceptsAdminTokenForGenerateEndpoint() throws Exception {
+        UidSecurityProperties properties = new UidSecurityProperties();
+        properties.setEnabled(true);
+        properties.setAdminTokens(List.of("admin"));
+        TokenAuthenticationFilter filter = new TokenAuthenticationFilter(properties, new ObjectMapper());
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/snowflake/uid");
+        request.addHeader("Authorization", "Bearer admin");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+    }
 }

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -7,10 +7,10 @@ export RAIN_BASE_URL=http://localhost:8080
 export RAIN_TOKEN=change-me
 export RAIN_BIZ_CODE=mxsm
 
-wrk -t4 -c128 -d60s -H "Authorization: Bearer ${RAIN_TOKEN}" \
+wrk -t4 -c128 -d60s -s scripts/perf/post.lua -H "Authorization: Bearer ${RAIN_TOKEN}" \
   "${RAIN_BASE_URL}/api/v1/snowflake/uid"
 
-wrk -t4 -c128 -d60s -H "Authorization: Bearer ${RAIN_TOKEN}" \
+wrk -t4 -c128 -d60s -s scripts/perf/post.lua -H "Authorization: Bearer ${RAIN_TOKEN}" \
   "${RAIN_BASE_URL}/api/v1/segment/uid/${RAIN_BIZ_CODE}"
 ```
 

--- a/scripts/perf/post.lua
+++ b/scripts/perf/post.lua
@@ -1,0 +1,2 @@
+wrk.method = "POST"
+wrk.headers["Content-Length"] = "0"


### PR DESCRIPTION
## Summary

Fixes #14

Correctness and robustness improvements across clock-backward handling, API security, segment queue observability, and a full migration to constructor injection.

---

## Changes

### Clock-Backward: deadline-based wait
- New `waitUntilMillis(target, maxWaitMs)` and `waitUntilSecond(target, maxWaitSec)` replace unbounded busy-spin loops
- Sleep 1–5 ms per iteration; hard `System.nanoTime()` deadline enforces `maxBackwardMillis`
- `InterruptedException` properly handled (interrupt flag restored + `UidUnavailableException` thrown)
- `onClockMovedBackwards()` called immediately on detection in all three generator code paths
- `getNextSecond()` fixed to sleep 1 ms instead of spinning
- Removed `randomMachineId()` — silent fallback to random IDs was masking configuration errors

### Admin-Token RBAC (`TokenAuthenticationFilter`)
- `POST /api/v1/segment/rg` now requires an **admin** token (`mxsm.uid.security.admin-tokens`)
- Regular tokens accepted for UID generation; admin tokens accepted everywhere
- Fixed `shouldNotFilter` to use `pathWithinApplication()` for correct context-path support
- Null-safe setters in `UidSecurityProperties`

### Segment Queue Backpressure
- `SegmentPanel.addSegment()` returns `boolean` / `int` (actual enqueued count); warns on drops
- `SegmentConsumerListenerImpl` records dropped segments via `uidMetrics.recordSegmentDiscarded(n)`
- New counter: `rain_uid_segment_discarded_total`

### GET → POST for UID Generation
- New canonical: `POST /api/v1/segment/uid/{bizCode}`, `POST /api/v1/snowflake/uid`
- Old `GET` variants kept as `@Deprecated` delegates (backwards-compatible)

### Constructor Injection
- `SegmentUidGeneratorController`, `SnowflakeUidGeneratorController`, `AllocationServiceImpl`, `SegmentConsumerListenerImpl`, `SegmentUidGeneratorServerImpl` — all field `@Autowired` replaced

### Segment Allocation Overflow Guard
- `null`/zero `stepLength` check in `AllocationServiceImpl`
- `Math.multiplyExact` overflow caught → `UidGenerateException(SEGMENT_ALLOCATE_FAILED)`

### Config
- `mxsm.uid.segment.wait-timeout-millis` (default `3000`) — max wait for available segment
- `mxsm.uid.security.admin-tokens`

### New Files
- `NoStoreCacheControlFilter` — adds `Cache-Control: no-store` to API responses
- `docs/api.md`, `docs/sdk.md`
- `scripts/perf/post.lua` — wrk2 POST script for load testing
- `.dockerignore`

### Tests
- `SegmentPanelTest`: timeout case + full-queue drop reporting
- `UidControllerResponseTest`: constructor injection; POST tests; deprecated GET test
- `TokenAuthenticationFilterTest`: admin-endpoint RBAC test
- `SnowflakeClientLocalBenchmark`: fixed `setMachineId(1)`

---

**43 files changed, 1258 insertions, 1057 deletions**
